### PR TITLE
Added ability to hide markers on click

### DIFF
--- a/files/js/mapdata-skellige.js
+++ b/files/js/mapdata-skellige.js
@@ -698,6 +698,9 @@ $(function()
 		], spoilsIcon, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'));
 
 	allLayers = [abandonedMarkers, alchemyMarkers, armourerMarkers, armourerstableMarkers, banditcampMarkers, barberMarkers, blacksmithMarkers, brothelMarkers, entranceMarkers, grindstoneMarkers, guardedMarkers, gwentMarkers, harborMarkers, herbalistMarkers, hiddenMarkers, innkeepMarkers, monsterdenMarkers, monsternestMarkers, noticeMarkers, pidMarkers, popMarkers, poiMarkers, shopkeeperMarkers, signpostMarkers, smugglersMarkers, spoilsMarkers];
+	var mapPath = 'markers-opacity-skellige';
+	initializeInvisibleMarkers(mapPath, allLayers);
+
 });
 
 function genericMarkers(cords, icon, label, popup) {

--- a/files/js/mapdata-velen.js
+++ b/files/js/mapdata-velen.js
@@ -943,6 +943,10 @@ $(function()
 		]);
 
 	allLayers = [abandonedMarkers, alchemyMarkers, armourerMarkers, armourerstableMarkers, banditcampMarkers, barberMarkers, blacksmithMarkers, brothelMarkers, entranceMarkers, grindstoneMarkers, guardedMarkers, gwentMarkers, harborMarkers, herbalistMarkers, hiddenMarkers, innkeepMarkers, monsterdenMarkers, monsternestMarkers, noticeMarkers, pidMarkers, popMarkers, poiMarkers, shopkeeperMarkers, signpostMarkers, smugglersMarkers, spoilsMarkers];
+
+	var mapPath = 'markers-opacity-velen';
+
+	initializeInvisibleMarkers(mapPath, allLayers);
 });
 
 function genericMarkers(cords, icon, label, popup) {

--- a/files/js/mapdata-white_orchard.js
+++ b/files/js/mapdata-white_orchard.js
@@ -312,6 +312,9 @@ $(function()
 		], spoilsIcon, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'));
 
 	allLayers = [abandonedMarkers, alchemyMarkers, armourerMarkers, armourerstableMarkers, banditcampMarkers, barberMarkers, blacksmithMarkers, brothelMarkers, entranceMarkers, grindstoneMarkers, guardedMarkers, gwentMarkers, harborMarkers, herbalistMarkers, hiddenMarkers, innkeepMarkers, monsterdenMarkers, monsternestMarkers, noticeMarkers, pidMarkers, popMarkers, poiMarkers, shopkeeperMarkers, signpostMarkers, smugglersMarkers, spoilsMarkers];
+
+	var mapPath = 'markers-opacity-white-orchard';
+	initializeInvisibleMarkers(mapPath, allLayers);
 });
 
 function genericMarkers(cords, icon, label, popup) {


### PR DESCRIPTION
Saw your post on /r/witcher and really liked the map. Kudos, dude!

I have added to toggle the visibility of markers by clicking on them. Hidden markers are saved to localStorage.

Markers will not be hidden completely but will get an opacity of 0.25. Sadly I could not test which would be the best value for the opacity because the map images wouldn't load. But you can alter the opacity setting by changing the variable ```invisibleMarkerOpacity``` in ```custom.js```. Please check what the best value would be.

The code is not perfect because most methods are added to the global scope. Feel free to change this :)

Keep on rocking, many thx for this website!