### PR TITLE
Added link to map selection page, cleaned up some JS

### DIFF
--- a/files/js/custom.js
+++ b/files/js/custom.js
@@ -12,6 +12,13 @@ $(function() {
 		$('#warn').remove();
 	}
 
+	var hackySticky = function () {
+		if ($(window).height() > $('#sidebar-wrap').outerHeight() + $('div#copyright').outerHeight() + 45) {
+			$('div#copyright').addClass('absolute');
+		} else {
+			$('div#copyright').removeClass('absolute');
+		}
+	};
 	hackySticky();
 	$(window).on('resize', function(){ hackySticky() });
 
@@ -25,7 +32,7 @@ $(function() {
 		cursorborder : 'none',
 	});
 
-	map = L.map('map', {
+	var map = L.map('map', {
 		minZoom: 2,
 		maxZoom: window.map_mZoom,
 		center: window.map_center,
@@ -34,6 +41,17 @@ $(function() {
 		zoomControl: false,
 		layers: allLayers
 	});
+
+	var go = function (cords) {
+		map.panTo(cords);
+		map.setZoom(window.map_mZoom);
+		new L.marker(cords, {
+			icon : L.icon({
+				iconUrl  : '/files/img/searchhover.png',
+				iconSize : [22, 22]
+			})
+		}).addTo(map);
+	};
 
 	new L.Control.Zoom({ position: 'topright' }).addTo(map);
 	new L.Control.Fullscreen({ position: 'topright' }).addTo(map);
@@ -274,38 +292,21 @@ $(function() {
 
 	$('div#copyright').on('click', 'a.js-credits', function(e) {
 		e.preventDefault();
-		alert('This page makes use of the following Javascript libraries:\n\njQuery (MIT) - http://jquery.com\njQuery.NiceScroll (MIT) - http://git.io/vkLly\nLeaflet (BSD2) - http://leafletjs.com\nLeaflet.label (MIT) - http://git.io/vkfA2\nLeaflet-hash (MIT) - http://git.io/mwK1oA\nLeaflet.fullscreen (BSD2) - http://git.io/vJw5v\nLeaflet Control Search (MIT) - http://git.io/vkCPC\n\nMany thanks to the developers for their hard work');
+		alert([
+			'This page makes use of the following Javascript libraries:',
+			'',
+			'jQuery (MIT) - http://jquery.com',
+			'jQuery.NiceScroll (MIT) - http://git.io/vkLly',
+			'Leaflet (BSD2) - http://leafletjs.com',
+			'Leaflet.label (MIT) - http://git.io/vkfA2',
+			'Leaflet-hash (MIT) - http://git.io/mwK1oA',
+			'Leaflet.fullscreen (BSD2) - http://git.io/vJw5v',
+			'Leaflet Control Search (MIT) - http://git.io/vkCPC',
+			'',
+			'Many thanks to the developers for their hard work.'
+		].join('\n'));
 	});
+
+
 });
 
-function go(cords) {
-	map.panTo(cords);
-	map.setZoom(window.map_mZoom);
-	new L.marker(cords, {
-		icon : L.icon({
-			iconUrl  : '/files/img/searchhover.png',
-			iconSize : [22, 22]
-		})
-	}).addTo(map);
-}
-
-function hackySticky() {
-	if ($(window).height() > $('#sidebar-wrap').outerHeight() + $('div#copyright').outerHeight() + 45) {
-		$('div#copyright').addClass('absolute');
-	} else {
-		$('div#copyright').removeClass('absolute');
-	}
-}
-
-function genericMarkers(cords, icon, label, popup) {
-	var out = [];
-	$.each(cords, function(key, val)
-	{
-		out.push(L.marker(val, setMarker(icon)).bindLabel(label).bindPopup(popup));
-	});
-	return out;
-}
-
-function setMarker(icon, tooltip) {
-	return {icon : icon, riseOnHover : true};
-}

--- a/files/js/custom.js
+++ b/files/js/custom.js
@@ -1,5 +1,4 @@
-$(function()
-{
+$(function() {
 	var mobile   = ($('#sidebar').width() < 300);
 	var wayPoint = false;
 
@@ -28,8 +27,8 @@ $(function()
 
 	map = L.map('map', {
 		minZoom: 2,
-		maxZoom: map_mZoom,
-		center: map_center,
+		maxZoom: window.map_mZoom,
+		center: window.map_center,
 		zoom: 3,
 		attributionControl: false,
 		zoomControl: false,
@@ -39,7 +38,7 @@ $(function()
 	new L.Control.Zoom({ position: 'topright' }).addTo(map);
 	new L.Control.Fullscreen({ position: 'topright' }).addTo(map);
 	var hash = new L.Hash(map);
-	var bounds = new L.LatLngBounds(map_sWest, map_nEast);
+	var bounds = new L.LatLngBounds(window.map_sWest, window.map_nEast);
 	map.setMaxBounds(bounds);
 
 	if (!mobile) {
@@ -86,7 +85,7 @@ $(function()
 		});
 	}
 
-	L.tileLayer('/files/maps/' + map_path + '/{z}/{x}/{y}.png', {
+	L.tileLayer('/files/maps/' + window.map_path + '/{z}/{x}/{y}.png', {
 		tms: true,
 		bounds: bounds,
 		noWrap: true
@@ -152,18 +151,18 @@ $(function()
 		map.closePopup();
 	});
 
-	if (localStorage['markers-' + map_path]) {
-		$.each($.parseJSON(localStorage['markers-' + map_path]), function(key, val) {
+	if (localStorage['markers-' + window.map_path]) {
+		$.each($.parseJSON(localStorage['markers-' + window.map_path]), function(key, val) {
 			if (val === false) {
 				$('i.' + key).parent().addClass('layer-disabled');
-				map.removeLayer(eval(key + 'Markers'));
+				map.removeLayer(window.markers[key]);
 			}
 		});
 	}
 
 	$('ul.key').on('click', 'li:not(.none)', function(e) {
 		var marker   = $(this).find('i').attr('class');
-		var remember = (!localStorage['markers-' + map_path]) ? {} : $.parseJSON(localStorage['markers-' + map_path]);
+		var remember = (!localStorage['markers-' + window.map_path]) ? {} : $.parseJSON(localStorage['markers-' + window.map_path]);
 		if (marker == 'hide') {
 			$.each(allLayers, function(key, val) {
 				map.removeLayer(val);
@@ -186,16 +185,16 @@ $(function()
 			});
 		} else {
 			if ($(this).hasClass('layer-disabled')) {
-				map.addLayer(eval(marker + 'Markers'));
+				map.addLayer(window.markers[marker]);
 				$(this).removeClass('layer-disabled');
 				remember[marker] = true;
 			} else {
-				map.removeLayer(eval(marker + 'Markers'));
+				map.removeLayer(window.markers[marker]);
 				$(this).addClass('layer-disabled');
 				remember[marker] = false;
 			}
 		}
-		localStorage['markers-' + map_path] = JSON.stringify(remember);
+		localStorage['markers-' + window.map_path] = JSON.stringify(remember);
 	});
 
 	var origSidebar;
@@ -224,8 +223,7 @@ $(function()
 	$(document).on('click', 'div#hide-sidebar.show-sidebar', function(e) {
 		$('#sidebar').animate({left : origSidebar}, 200);
 		$(this).animate({left : origHide}, 200);
-		$('#sidebar-border').animate({left : origBorder}, 200, function()
-		{
+		$('#sidebar-border').animate({left : origBorder}, 200, function() {
 			$('#map').css('left', origMap);
 			map.invalidateSize();
 			$('.show-sidebar').removeClass('show-sidebar');
@@ -282,7 +280,7 @@ $(function()
 
 function go(cords) {
 	map.panTo(cords);
-	map.setZoom(map_mZoom);
+	map.setZoom(window.map_mZoom);
 	new L.marker(cords, {
 		icon : L.icon({
 			iconUrl  : '/files/img/searchhover.png',
@@ -297,4 +295,17 @@ function hackySticky() {
 	} else {
 		$('div#copyright').removeClass('absolute');
 	}
+}
+
+function genericMarkers(cords, icon, label, popup) {
+	var out = [];
+	$.each(cords, function(key, val)
+	{
+		out.push(L.marker(val, setMarker(icon)).bindLabel(label).bindPopup(popup));
+	});
+	return out;
+}
+
+function setMarker(icon, tooltip) {
+	return {icon : icon, riseOnHover : true};
 }

--- a/files/js/mapdata-skellige.js
+++ b/files/js/mapdata-skellige.js
@@ -1,729 +1,601 @@
-$(function() {
+(function () {
 	window.map_path   = 'skellige';
 	window.map_sWest  = L.latLng(-85.05, -180);
 	window.map_nEast  = L.latLng(79.30, 135);
 	window.map_center = [-35, -10];
 	window.map_mZoom  = 6;
 
-	window.markers = {};
+	var icons = window.icons;
+	var markers = window.markers;
 
 	// Abandoned Site
-		var abandonedIcon = L.icon({
-			iconUrl  : '/files/img/icons/abandoned.png',
-			iconSize : [30, 30]
-		});
-
-		window.markers['abandoned'] = L.layerGroup(genericMarkers([
-			// Hindarsfjall
-				[-35.996, 92.439],
-				[-32.916, 85.562],
-			// Ard Skellig
-				[-45.522, -49.570],
-				[-23.745, -19.841],
-		], abandonedIcon, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more'));
+	markers.abandoned = L.layerGroup(genericMarkers([
+		// Hindarsfjall
+			[-35.996, 92.439],
+			[-32.916, 85.562],
+		// Ard Skellig
+			[-45.522, -49.570],
+			[-23.745, -19.841],
+	], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more'));
 
 	// Alchemy Supplies
-		var alchemyIcon = L.icon({
-			iconUrl  : '/files/img/icons/alchemy.png',
-			iconSize : [20, 28]
-		});
-
-		window.markers['alchemy'] = L.layerGroup([
-			L.marker([-20.468, 93.318], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies').bindPopup('<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
-			L.marker([-28.208, -26.147], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies').bindPopup('<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
-			L.marker([-19.705, 17.314], setMarker(alchemyIcon)).bindLabel('Gremist').bindPopup('<h1>Gremist</h1>\'Practicum in Advanced Alchemy\' (lvl 24) Quest'),
-		]);
+	markers.alchemy = L.layerGroup([
+		createMarker([-20.468, 93.318], icons.alchemy, 'Alchemy Supplies', '<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
+		createMarker([-28.208, -26.147], icons.alchemy, 'Alchemy Supplies', '<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
+		createMarker([-19.705, 17.314], icons.alchemy, 'Gremist', '<h1>Gremist</h1>\'Practicum in Advanced Alchemy\' (lvl 24) Quest'),
+	]);
 
 	// Armourer
-		var armourerIcon = L.icon({
-			iconUrl  : '/files/img/icons/armourer.png',
-			iconSize : [24, 34]
-		});
-
-		window.markers['armourer'] = L.layerGroup([
-			// Hindarsfjall
-				L.marker([-29.037, 98.569], setMarker(armourerIcon)).bindLabel('Amateur Armorer').bindPopup('<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// An Skellig
-				L.marker([49.253, 39.243], setMarker(armourerIcon)).bindLabel('Amateur Armorer').bindPopup('<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// Ard Skellig
-				L.marker([-62.492, -37.705], setMarker(armourerIcon)).bindLabel('Journeyman Armorer').bindPopup('<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-				L.marker([2.965, -40.210], setMarker(armourerIcon)).bindLabel('Journeyman Armorer').bindPopup('<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		]);
+	markers.armourer = L.layerGroup([
+		// Hindarsfjall
+			createMarker([-29.037, 98.569], icons.armourer, 'Amateur Armorer', '<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// An Skellig
+			createMarker([49.253, 39.243], icons.armourer, 'Amateur Armorer', '<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// Ard Skellig
+			createMarker([-62.492, -37.705], icons.armourer, 'Journeyman Armorer', '<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+			createMarker([2.965, -40.210], icons.armourer, 'Journeyman Armorer', '<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+	]);
 
 	// Armourer's Table
-		var armourerstableIcon = L.icon({
-			iconUrl  : '/files/img/icons/armourerstable.png',
-			iconSize : [30, 27]
-		});
-
-		window.markers['armourerstable'] = L.layerGroup(genericMarkers([
-			// Hindarsfjall
-				[-28.159, 101.851],
-				[-28.825, 98.062],
-				[-32.806, 84.771],
-			// An Skellig
-				[50.247, 39.529],
-			// Spikeroog
-				[33.560, -111.445],
-			// Ard Skellig
-				[-62.127, -37.375],
-				[-39.455, -63.127],
-				[2.826, -40.997],
-		], armourerstableIcon, 'Armorer\'s Table', '<h1>Armorer\'s Table</h1>Armorer\'s tables grant your gear increased armor for a limited duration'));
+	markers.armourerstable = L.layerGroup(genericMarkers([
+		// Hindarsfjall
+			[-28.159, 101.851],
+			[-28.825, 98.062],
+			[-32.806, 84.771],
+		// An Skellig
+			[50.247, 39.529],
+		// Spikeroog
+			[33.560, -111.445],
+		// Ard Skellig
+			[-62.127, -37.375],
+			[-39.455, -63.127],
+			[2.826, -40.997],
+	], icons.armourerstable, 'Armorer\'s Table', '<h1>Armorer\'s Table</h1>Armorer\'s tables grant your gear increased armor for a limited duration'));
 
 	// Bandit Camp
-		var banditcampIcon = L.icon({
-			iconUrl  : '/files/img/icons/banditcamp.png',
-			iconSize : [29, 30]
-		});
-
-		window.markers['banditcamp'] = L.layerGroup(genericMarkers([
-			// Spikeroog
-				[21.861, -121.047],
-			// Ard Skellig
-				[-61.260, -50.669],
-				[-29.459, -17.886],
-				[-14.562, 27.861],
-				[5.616, 15.557],
-			// Sea
-				[20.797, 38.848],
-		], banditcampIcon, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here'));
+	markers.banditcamp = L.layerGroup(genericMarkers([
+		// Spikeroog
+			[21.861, -121.047],
+		// Ard Skellig
+			[-61.260, -50.669],
+			[-29.459, -17.886],
+			[-14.562, 27.861],
+			[5.616, 15.557],
+		// Sea
+			[20.797, 38.848],
+	], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here'));
 
 	// Barber
-		var barberIcon = L.icon({
-			iconUrl  : '/files/img/icons/barber.png',
-			iconSize : [30, 30]
-		});
-
-		window.markers['barber'] = L.layerGroup(genericMarkers([
-			// Spikeroog
-				[31.072, -111.973],
-				[-3.601, -34.277],
-		], barberIcon, 'Barber', '<h1>Barber</h1>Visit barbers for a shave or a new haircut'));
+	markers.barber = L.layerGroup(genericMarkers([
+		// Spikeroog
+			[31.072, -111.973],
+			[-3.601, -34.277],
+	], icons.barber, 'Barber', '<h1>Barber</h1>Visit barbers for a shave or a new haircut'));
 
 	// Blacksmith
-		var blacksmithIcon = L.icon({
-			iconUrl  : '/files/img/icons/blacksmith.png',
-			iconSize : [27, 30]
-		});
-
-		window.markers['blacksmith'] = L.layerGroup([
-			// Faroe
-				L.marker([-77.390, 50.142], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// Hindarsfjall
-				L.marker([-28.613, 102.458], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// An Skellig
-				L.marker([50.641, 38.013], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// Spikeroog
-				L.marker([33.101, -111.709], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// Ard Skellig
-				L.marker([-62.007, -37.903], setMarker(blacksmithIcon)).bindLabel('Journeyman Blacksmith').bindPopup('<h1>Journeyman Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-				L.marker([-39.504, -63.647], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-				L.marker([-37.265, -32.014], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-				L.marker([-56.945, -15.513], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-				L.marker([3.141, -40.649], setMarker(blacksmithIcon)).bindLabel('Journeyman Blacksmith').bindPopup('<h1>Journeyman Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		]);
+	markers.blacksmith = L.layerGroup([
+		// Faroe
+			createMarker([-77.390, 50.142], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// Hindarsfjall
+			createMarker([-28.613, 102.458], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// An Skellig
+			createMarker([50.641, 38.013], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// Spikeroog
+			createMarker([33.101, -111.709], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// Ard Skellig
+			createMarker([-62.007, -37.903], icons.blacksmith, 'Journeyman Blacksmith', '<h1>Journeyman Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+			createMarker([-39.504, -63.647], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+			createMarker([-37.265, -32.014], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+			createMarker([-56.945, -15.513], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+			createMarker([3.141, -40.649], icons.blacksmith, 'Journeyman Blacksmith', '<h1>Journeyman Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+	]);
 
 	// Brothel
-		var brothelIcon = L.icon({
-			iconUrl  : '/files/img/icons/brothel.png',
-			iconSize : [28, 26]
-		});
-
-		window.markers['brothel'] = L.layerGroup([]);
+	markers.brothel = L.layerGroup([]);
 
 	// Entrance
-		var entranceIcon = L.icon({
-			iconUrl  : '/files/img/icons/entrance.png',
-			iconSize : [28, 27]
-		});
-
 		// todo, entrance to what?
-		window.markers['entrance'] = L.layerGroup([
-			// Faroe
-				L.marker([-78.469, 43.484], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-77.250, 44.187], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// Hindarsfjall
-				L.marker([-17.036, 91.230], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-18.750, 88.022], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-18.813, 108.677], setMarker(entranceIcon)).bindLabel('Underwater Cave').bindPopup('<h1>Underwater Cave</h1>Underwater entrance to cave'),
-				L.marker([-25.205, 92.769], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-28.033, 89.912], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-29.955, 94.131], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// An Skellig
-				L.marker([50.317, 33.289], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// Spikeroog
-				L.marker([17.225, -123.640], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// Eastern Islands
-				L.marker([-15.623, -139.043], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// Undvik
-				L.marker([-51.727, -134.517], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-60.791, -127.375], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-61.470, -122.278], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-56.933, -124.343], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-59.108, -111.313], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// Ard Skellig
-				L.marker([-71.124, -8.525], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-69.756, -8.503], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-69.938, -23.906], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-52.389, -42.473], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-45.722, -30.256], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-23.322, -67.983], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-18.396, -38.804], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-56.801, 23.379], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-54.581, 12.964], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-47.145, 17.468], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-44.072, 6.350], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-12.897, -13.667], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-13.240, -27.598], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-20.056, 17.446], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-1.801, -1.099], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([9.926, -22.168], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-		]);
+	markers.entrance = L.layerGroup([
+		// Faroe
+			createMarker([-78.469, 43.484], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-77.250, 44.187], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// Hindarsfjall
+			createMarker([-17.036, 91.230], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-18.750, 88.022], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-18.813, 108.677], icons.entrance, 'Underwater Cave', '<h1>Underwater Cave</h1>Underwater entrance to cave'),
+			createMarker([-25.205, 92.769], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-28.033, 89.912], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-29.955, 94.131], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// An Skellig
+			createMarker([50.317, 33.289], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// Spikeroog
+			createMarker([17.225, -123.640], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// Eastern Islands
+			createMarker([-15.623, -139.043], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// Undvik
+			createMarker([-51.727, -134.517], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-60.791, -127.375], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-61.470, -122.278], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-56.933, -124.343], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-59.108, -111.313], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// Ard Skellig
+			createMarker([-71.124, -8.525], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-69.756, -8.503], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-69.938, -23.906], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-52.389, -42.473], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-45.722, -30.256], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-23.322, -67.983], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-18.396, -38.804], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-56.801, 23.379], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-54.581, 12.964], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-47.145, 17.468], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-44.072, 6.350], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-12.897, -13.667], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-13.240, -27.598], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-20.056, 17.446], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-1.801, -1.099], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([9.926, -22.168], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+	]);
 
 	// Grindstone
-		var grindstoneIcon = L.icon({
-			iconUrl  : '/files/img/icons/grindstone.png',
-			iconSize : [30, 26]
-		});
-
-		window.markers['grindstone'] = L.layerGroup(genericMarkers([
-			// Faroe
-				[-77.355, 50.647],
-			// Hindarsfjall
-				[-28.420, 102.119],
-				[-28.929, 97.754],
-				[-32.990, 84.902],
-			// An Skellig
-				[50.499, 39.836],
-			// Spikeroog
-				[33.340, -111.357],
-			// Ard Skellig
-				[-62.390, -37.156],
-				[-39.317, -62.996],
-				[-23.564, -20.522],
-				[2.526, -40.957],
-		], grindstoneIcon, 'Grindstone', '<h1>Grindstone</h1>A blade sharpened here will deal more damage'));
+	markers.grindstone = L.layerGroup(genericMarkers([
+		// Faroe
+			[-77.355, 50.647],
+		// Hindarsfjall
+			[-28.420, 102.119],
+			[-28.929, 97.754],
+			[-32.990, 84.902],
+		// An Skellig
+			[50.499, 39.836],
+		// Spikeroog
+			[33.340, -111.357],
+		// Ard Skellig
+			[-62.390, -37.156],
+			[-39.317, -62.996],
+			[-23.564, -20.522],
+			[2.526, -40.957],
+	], icons.grindstone, 'Grindstone', '<h1>Grindstone</h1>A blade sharpened here will deal more damage'));
 
 	// Guarded Treasure
-		var guardedIcon = L.icon({
-			iconUrl  : '/files/img/icons/guarded.png',
-			iconSize : [23, 34]
-		});
+	var guardedGeneric = genericMarkers([
+		// Faroe
+			[-75.958, 43.835],
+		// Hindarsfjall
+			[-22.472, 85.386],
+		// Undvik
+			[-46.134, -120.586],
+			[-69.877, -160.225],
+		// Ard Skellig
+			[-70.873, -5.625],
+			[-66.531, -15.908],
+			[-53.278, -63.413],
+			[-46.815, -37.639],
+			[-21.678, -32.717],
+			[-26.392, -5.142],
+			[-13.625, -43.506],
+			[-23.765, 23.291],
+			[5.791, -17.754],
+		// Sea
+			[28.111, 91.406],
+			[-73.788, 20.347],
+			[-70.215, 35.552],
+			[53.801, -64.336],
+			[55.279, -40.869],
+			[55.826, -30.674],
+			[59.623, -26.279],
+			[61.058, -17.754],
+			[57.845, -1.670],
+	], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
 
-		var guardedGeneric = genericMarkers([
-			// Faroe
-				[-75.958, 43.835],
-			// Hindarsfjall
-				[-22.472, 85.386],
-			// Undvik
-				[-46.134, -120.586],
-				[-69.877, -160.225],
-			// Ard Skellig
-				[-70.873, -5.625],
-				[-66.531, -15.908],
-				[-53.278, -63.413],
-				[-46.815, -37.639],
-				[-21.678, -32.717],
-				[-26.392, -5.142],
-				[-13.625, -43.506],
-				[-23.765, 23.291],
-				[5.791, -17.754],
-			// Sea
-				[28.111, 91.406],
-				[-73.788, 20.347],
-				[-70.215, 35.552],
-				[53.801, -64.336],
-				[55.279, -40.869],
-				[55.826, -30.674],
-				[59.623, -26.279],
-				[61.058, -17.754],
-				[57.845, -1.670],
-		], guardedIcon, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
-
-		window.markers['guarded'] = L.layerGroup($.merge(guardedGeneric, [
-			// No custom markers needed
-		]));
+	markers.guarded = L.layerGroup($.merge(guardedGeneric, [
+		// No custom markers needed
+	]));
 
 	// Gwent Player
-		var gwentIcon = L.icon({
-			iconUrl  : '/files/img/icons/gwent.png',
-			iconSize : [24, 30]
-		});
-
-		window.markers['gwent'] = L.layerGroup([
-			// Faroe
-				L.marker([-77.455, 49.227], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-77.350, 50.242], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			// Hindarsfjall
-				L.marker([-29.206, 99.662], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-28.985, 100.993], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-28.513, 102.658], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-28.937, 98.769], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			// An Skellig
-				L.marker([50.701, 38.203], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([50.669, 40.630], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([49.313, 39.443], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			// Spikeroog
-				L.marker([33.201, -111.909], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([31.360, -110.856], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([31.361, -112.799], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			// Ard Skellig
-				L.marker([-62.442, -37.585], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-61.917, -37.753], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-64.003, -47.744], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-42.031, -61.873], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-39.404, -63.487], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-37.165, -31.814], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-37.584, -29.837], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-56.435, -13.731], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-56.845, -15.313], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([3.085, -40.010], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([3.241, -40.449], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-30.576, -2.481], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-5.997, -34.407], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Herbalist Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-3.194, -35.967], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-		]);
+	markers.gwent = L.layerGroup([
+		// Faroe
+			createMarker([-77.455, 49.227], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-77.350, 50.242], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+		// Hindarsfjall
+			createMarker([-29.206, 99.662], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-28.985, 100.993], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-28.513, 102.658], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-28.937, 98.769], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+		// An Skellig
+			createMarker([50.701, 38.203], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([50.669, 40.630], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([49.313, 39.443], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+		// Spikeroog
+			createMarker([33.201, -111.909], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([31.360, -110.856], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([31.361, -112.799], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+		// Ard Skellig
+			createMarker([-62.442, -37.585], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-61.917, -37.753], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-64.003, -47.744], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-42.031, -61.873], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-39.404, -63.487], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-37.165, -31.814], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-37.584, -29.837], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-56.435, -13.731], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-56.845, -15.313], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([3.085, -40.010], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([3.241, -40.449], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-30.576, -2.481], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-5.997, -34.407], icons.gwent, 'Gwent Player', '<h1>Herbalist Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-3.194, -35.967], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+	]);
 
 	// Harbor
-		var harborIcon = L.icon({
-			iconUrl  : '/files/img/icons/harbor.png',
-			iconSize : [27, 30]
-		});
-
-		window.markers['harbor'] = L.layerGroup(genericMarkers([
-			[-6.075, -40.496],
-			[11.265, -23.005],
-			[-28.498, -28.696],
-			[-38.514, -65.544],
-			[-23.403, -75.388],
-			[-50.972, -106.721],
-			[-43.628, -116.301],
-			[-64.053, -52.207],
-			[-76.496, 53.394],
-			[-58.101, -12.349],
-			[-59.955, -2.944],
-			[-57.065, 25.796],
-			[-25.681, 100.767],
-			[-31.915, 26.938],
-			[47.725, 38.628],
-			[32.769, -107.974],
-			[-14.477, -141.064],
-		], harborIcon, 'Harbor', '<h1>Harbor</h1>A place where you can find a boat, boats will respawn here'));
+	markers.harbor = L.layerGroup(genericMarkers([
+		[-6.075, -40.496],
+		[11.265, -23.005],
+		[-28.498, -28.696],
+		[-38.514, -65.544],
+		[-23.403, -75.388],
+		[-50.972, -106.721],
+		[-43.628, -116.301],
+		[-64.053, -52.207],
+		[-76.496, 53.394],
+		[-58.101, -12.349],
+		[-59.955, -2.944],
+		[-57.065, 25.796],
+		[-25.681, 100.767],
+		[-31.915, 26.938],
+		[47.725, 38.628],
+		[32.769, -107.974],
+		[-14.477, -141.064],
+	], icons.harbor, 'Harbor', '<h1>Harbor</h1>A place where you can find a boat, boats will respawn here'));
 
 	// Herbalist
-		var herbalistIcon = L.icon({
-			iconUrl  : '/files/img/icons/herbalist.png',
-			iconSize : [25, 28]
-		});
+	var herbalistGeneric = genericMarkers([
+		// Ard Skellig
+			[-32.473, 14.722],
+			[-6.097, -34.607],
+	], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>Here you can buy alchemy ingredients');
 
-		var herbalistGeneric = genericMarkers([
-			// Ard Skellig
-				[-32.473, 14.722],
-				[-6.097, -34.607],
-		], herbalistIcon, 'Herbalist', '<h1>Herbalist</h1>Here you can buy alchemy ingredients');
-
-		window.markers['herbalist'] = L.layerGroup($.merge(herbalistGeneric, [
-			// No custom markers needed
-		]));
+	markers.herbalist = L.layerGroup($.merge(herbalistGeneric, [
+		// No custom markers needed
+	]));
 
 
 	// Hidden Treasure
-		var hiddenIcon = L.icon({
-			iconUrl  : '/files/img/icons/hidden.png',
-			iconSize : [23, 34]
-		});
+	var hiddenGeneric = genericMarkers([
+		// Faroe
+			[-78.469, 42.957],
+		// An Skellig
+			[46.905, 46.582],
+		// Spikeroog
+			[26.274, -104.238],
+			[27.020, -95.977],
+		// Undvik
+			[-46.073, -133.835],
+			[-55.937, -121.223],
+			[-56.317, -150.073],
+			[-45.568, -102.327],
+		// Eastern Islands
+			[-12.039, -98.701],
+		// Ard Skellig
+			[-72.262, 5.317],
+			[-58.825, -3.735],
+			[-32.287, -50.757],
+			[-40.028, -18.083],
+			[-38.857, -26.543],
+			[-24.127, -69.829],
+			[-36.315, 0.264],
+			[-21.739, 30.498],
+			[2.021, -21.709],
+		// Sea
+			[4.083, -78.223],
+			[31.541, -65.566],
+			[38.788, -21.533],
+			[-65.658, 41.396],
+			[-78.044, -41.968],
+			[63.666, -88.154],
+			[50.373, -7.515],
+	], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
 
-		var hiddenGeneric = genericMarkers([
-			// Faroe
-				[-78.469, 42.957],
-			// An Skellig
-				[46.905, 46.582],
-			// Spikeroog
-				[26.274, -104.238],
-				[27.020, -95.977],
-			// Undvik
-				[-46.073, -133.835],
-				[-55.937, -121.223],
-				[-56.317, -150.073],
-				[-45.568, -102.327],
-			// Eastern Islands
-				[-12.039, -98.701],
-			// Ard Skellig
-				[-72.262, 5.317],
-				[-58.825, -3.735],
-				[-32.287, -50.757],
-				[-40.028, -18.083],
-				[-38.857, -26.543],
-				[-24.127, -69.829],
-				[-36.315, 0.264],
-				[-21.739, 30.498],
-				[2.021, -21.709],
-			// Sea
-				[4.083, -78.223],
-				[31.541, -65.566],
-				[38.788, -21.533],
-				[-65.658, 41.396],
-				[-78.044, -41.968],
-				[63.666, -88.154],
-				[50.373, -7.515],
-		], hiddenIcon, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
-
-		window.markers['hidden'] = L.layerGroup($.merge(hiddenGeneric, [
-			// No custom markers needed
-		]));
+	markers.hidden = L.layerGroup($.merge(hiddenGeneric, [
+		// No custom markers needed
+	]));
 
 	// Innkeep
-		var innkeepIcon = L.icon({
-			iconUrl  : '/files/img/icons/tavern.png',
-			iconSize : [26, 30]
-		});
-
-		window.markers['innkeep'] = L.layerGroup([
-			// Faroe
-				L.marker([-77.485, 49.007], setMarker(innkeepIcon)).bindLabel('Harviken Inn').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-			// Hindarsfjall
-				L.marker([-29.075, 100.723], setMarker(innkeepIcon)).bindLabel('House of Warriors').bindPopup('<h1>Innkeep</h1>Sells Food, and drink'),
-			// An Skellig
-				L.marker([50.569, 40.430], setMarker(innkeepIcon)).bindLabel('Urialla Harbour Inn').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-			// Spikeroog
-				L.marker([31.241, -113.049], setMarker(innkeepIcon)).bindLabel('Svorlag Inn').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-			// Ard Skellig
-				L.marker([-42.131, -62.073], setMarker(innkeepIcon)).bindLabel('Arinbjorn Inn').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-				L.marker([-3.294, -36.167], setMarker(innkeepIcon)).bindLabel('The New Port').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-		]);
+	markers.innkeep = L.layerGroup([
+		// Faroe
+			createMarker([-77.485, 49.007], icons.innkeep, 'Harviken Inn', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
+		// Hindarsfjall
+			createMarker([-29.075, 100.723], icons.innkeep, 'House of Warriors', '<h1>Innkeep</h1>Sells Food, and drink'),
+		// An Skellig
+			createMarker([50.569, 40.430], icons.innkeep, 'Urialla Harbour Inn', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
+		// Spikeroog
+			createMarker([31.241, -113.049], icons.innkeep, 'Svorlag Inn', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
+		// Ard Skellig
+			createMarker([-42.131, -62.073], icons.innkeep, 'Arinbjorn Inn', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
+			createMarker([-3.294, -36.167], icons.innkeep, 'The New Port', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
+	]);
 
 	// Monster Den
-		var monsterdenIcon = L.icon({
-			iconUrl  : '/files/img/icons/monsterden.png',
-			iconSize : [30, 27]
-		});
+	var monsterdenGeneric = genericMarkers([
+		// Faroe
+			[-78.587, 68.071],
+			[-77.133, 56.646],
+		// Ard Skellig
+			[-50.078, -33.245],
+			[-10.401, 1.758],
+			[-5.922, 8.262],
+			[-2.416, -21.841],
+	], icons.monsterden, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby');
 
-		var monsterdenGeneric = genericMarkers([
-			// Faroe
-				[-78.587, 68.071],
-				[-77.133, 56.646],
-			// Ard Skellig
-				[-50.078, -33.245],
-				[-10.401, 1.758],
-				[-5.922, 8.262],
-				[-2.416, -21.841],
-		], monsterdenIcon, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby');
-
-		window.markers['monsterden'] = L.layerGroup($.merge(monsterdenGeneric, [
-			// No custom markers needed
-		]));
+	markers.monsterden = L.layerGroup($.merge(monsterdenGeneric, [
+		// No custom markers needed
+	]));
 
 	// Monster Nest
-		var monsternestIcon = L.icon({
-			iconUrl  : '/files/img/icons/monsternest.png',
-			iconSize : [23, 30]
-		});
+	var monsternestGeneric = genericMarkers([
+		// An Skellig
+			[50.458, 26.521],
+		// Ard Skellig
+			[-59.074, -24.521],
+			[-59.120, -4.131],
+			[-24.827, -29.070],
+			[-23.544, -37.551],
+	], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
 
-		var monsternestGeneric = genericMarkers([
-			// An Skellig
-				[50.458, 26.521],
-			// Ard Skellig
-				[-59.074, -24.521],
-				[-59.120, -4.131],
-				[-24.827, -29.070],
-				[-23.544, -37.551],
-		], monsternestIcon, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
-
-		window.markers['monsternest'] = L.layerGroup($.merge(monsternestGeneric, [
-			// No custom markers needed
-		]));
+	markers.monsternest = L.layerGroup($.merge(monsternestGeneric, [
+		// No custom markers needed
+	]));
 
 	// Notice Board
-		var noticeIcon = L.icon({
-			iconUrl  : '/files/img/icons/notice.png',
-			iconSize : [23, 28]
-		});
-
-		window.markers['notice'] = L.layerGroup(genericMarkers([
-			// Hindarsfjall
-				[-28.343, 100.239],
-			// Spikeroog
-				[31.996, -111.313],
-			// Ard Skellig
-				[-63.095, -43.594],
-				[-42.844, -62.996],
-				[-27.547, -25.005],
-				[-55.454, -15.337],
-				[-30.468, -1.890],
-				[-6.905, -35.178],
-		], noticeIcon, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
+	markers.notice = L.layerGroup(genericMarkers([
+		// Hindarsfjall
+			[-28.343, 100.239],
+		// Spikeroog
+			[31.996, -111.313],
+		// Ard Skellig
+			[-63.095, -43.594],
+			[-42.844, -62.996],
+			[-27.547, -25.005],
+			[-55.454, -15.337],
+			[-30.468, -1.890],
+			[-6.905, -35.178],
+	], icons.notice, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
 
 	// Person in Distress
-		var pidIcon = L.icon({
-			iconUrl  : '/files/img/icons/pid.png',
-			iconSize : [24, 34]
-		});
+	var pidGeneric = genericMarkers([
+		[-33.633, -40.298],
+		[-38.994, -6.372],
+	], icons.pid, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance');
 
-		var pidGeneric = genericMarkers([
-			[-33.633, -40.298],
-			[-38.994, -6.372],
-		], pidIcon, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance');
-
-		window.markers['pid'] = L.layerGroup($.merge(pidGeneric, [
-			// No custom markers needed
-		]));
+	markers.pid = L.layerGroup($.merge(pidGeneric, [
+		// No custom markers needed
+	]));
 
 	// Place of Power
-		var popIcon = L.icon({
-			iconUrl  : '/files/img/icons/pop.png',
-			iconSize : [27, 30]
-		});
-
 		//todo get all place of power types
-		window.markers['pop'] = L.layerGroup([
-			// Faroe
-				L.marker([-76.851, 40.891], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'),
-			// An Skellig
-				L.marker([54.496, 35.903], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'),
-			// Spikeroog
-				L.marker([34.343, -120.564], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Igni</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'),
-			// Ard Skellig
-				L.marker([-57.350, -48.604], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Axii</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-				L.marker([-24.667, -36.497], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-				L.marker([-32.194, 15.710], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-				L.marker([4.784, -42.451], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-				L.marker([-21.576, 29.795], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-				L.marker([4.390, -25.708], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-		]);
+	markers.pop = L.layerGroup([
+		// Faroe
+			createMarker([-76.851, 40.891], icons.pop, 'Place of Power', '<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'),
+		// An Skellig
+			createMarker([54.496, 35.903], icons.pop, 'Place of Power', '<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'),
+		// Spikeroog
+			createMarker([34.343, -120.564], icons.pop, 'Place of Power', '<h1>Place of Power - Igni</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'),
+		// Ard Skellig
+			createMarker([-57.350, -48.604], icons.pop, 'Place of Power', '<h1>Place of Power - Axii</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+			createMarker([-24.667, -36.497], icons.pop, 'Place of Power', '<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+			createMarker([-32.194, 15.710], icons.pop, 'Place of Power', '<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+			createMarker([4.784, -42.451], icons.pop, 'Place of Power', '<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+			createMarker([-21.576, 29.795], icons.pop, 'Place of Power', '<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+			createMarker([4.390, -25.708], icons.pop, 'Place of Power', '<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+	]);
 
 	// Point of Interest
-		var poiIcon = L.icon({
-			iconUrl  : '/files/img/icons/poi.png',
-			iconSize : [28, 28]
-		});
 
-
-		window.markers['poi'] = L.layerGroup([
+		markers.poi = L.layerGroup([
 			// Faroe
-				L.marker([-76.985, 57.788], setMarker(poiIcon)).bindLabel('Jutta An Dimun').bindPopup('<h1>Jutta An Dimun</h1>todo'), //double check this
+				createMarker([-76.985, 57.788], icons.poi, 'Jutta An Dimun', '<h1>Jutta An Dimun</h1>todo'), //double check this
 			// Ard Skellig
-				L.marker([-58.344, -2.549], setMarker(poiIcon)).bindLabel('Ursine Steel Sword').bindPopup('<h1>Ursine Steel Sword Diagram</h1>In a chest in the basement of this ruin'),
-				L.marker([-40.112, -14.546], setMarker(poiIcon)).bindLabel('Griffin Steel Sword Mastercrafted').bindPopup('<h1>Griffin Steel Sword Mastercrafted</h1>'),
-				L.marker([-1.274, -11.931], setMarker(poiIcon)).bindLabel('Enhanced Ursine Gauntlets').bindPopup('<h1>Enhanced Ursine Gauntlets Diagram</h1>'),
-				L.marker([8.559, 13.733], setMarker(poiIcon)).bindLabel('Superior Griffin Armour Set').bindPopup('<h1>Superior Griffin Armour Set Diagrams</h1>Armor, boots, gauntlets, trousers'),
+				createMarker([-58.344, -2.549], icons.poi, 'Ursine Steel Sword', '<h1>Ursine Steel Sword Diagram</h1>In a chest in the basement of this ruin'),
+				createMarker([-40.112, -14.546], icons.poi, 'Griffin Steel Sword Mastercrafted', '<h1>Griffin Steel Sword Mastercrafted</h1>'),
+				createMarker([-1.274, -11.931], icons.poi, 'Enhanced Ursine Gauntlets', '<h1>Enhanced Ursine Gauntlets Diagram</h1>'),
+				createMarker([8.559, 13.733], icons.poi, 'Superior Griffin Armour Set', '<h1>Superior Griffin Armour Set Diagrams</h1>Armor, boots, gauntlets, trousers'),
 				
 		]);
 
 	// Shopkeeper
-		var shopkeeperIcon = L.icon({
-			iconUrl  : '/files/img/icons/merchant.png',
-			iconSize : [21, 30]
-		});
-
-		window.markers['shopkeeper'] = L.layerGroup([
-			// Hindarsfjall
-				L.marker([-29.306, 99.492], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells crafting supplies and fish'),
-			// Spikeroog
-				L.marker([31.260, -111.006], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells crafting supplies and fish'),
-			// Ard Skellig
-				L.marker([-64.063, -47.944], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells maps, crafting supplies, fish and \'Mastercrafted Cavalry Saddle\' (+75)'),
-				L.marker([-60.555, -51.416], setMarker(shopkeeperIcon)).bindLabel('Wandering Merchant').bindPopup('<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-				L.marker([-42.747, -58.535], setMarker(shopkeeperIcon)).bindLabel('Wandering Merchant').bindPopup('<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-				L.marker([-43.229, -49.175], setMarker(shopkeeperIcon)).bindLabel('Wandering Merchant').bindPopup('<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-				L.marker([-32.045, -17.996], setMarker(shopkeeperIcon)).bindLabel('Wandering Merchant').bindPopup('<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-				L.marker([-24.107, -22.632], setMarker(shopkeeperIcon)).bindLabel('Wandering Merchant').bindPopup('<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-				L.marker([-37.684, -30.037], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells maps and crafting supplies'),
-				L.marker([-56.535, -13.931], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells crafting supplies and fish'),
-				L.marker([-22.837, -20.522], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells armour and crafting supplies'),
-				L.marker([-30.676, -2.681], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells maps, crafting supplies, food, and drink'),
-				L.marker([-14.541, -32.080], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells maps and crafting supplies'),
-				L.marker([-7.559, -40.408], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells maps and crafting supplies'),
-				L.marker([-3.401, -34.077], setMarker(shopkeeperIcon)).bindLabel('Tailor').bindPopup('<h1>Tailor</h1>Sells clothes and crafting supplies. Is also a barber'),
-				L.marker([-8.581, -34.321], setMarker(shopkeeperIcon)).bindLabel('Wandering Merchant').bindPopup('<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-		]);
+	markers.shopkeeper = L.layerGroup([
+		// Hindarsfjall
+			createMarker([-29.306, 99.492], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies and fish'),
+		// Spikeroog
+			createMarker([31.260, -111.006], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies and fish'),
+		// Ard Skellig
+			createMarker([-64.063, -47.944], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells maps, crafting supplies, fish and \'Mastercrafted Cavalry Saddle\' (+75)'),
+			createMarker([-60.555, -51.416], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
+			createMarker([-42.747, -58.535], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
+			createMarker([-43.229, -49.175], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
+			createMarker([-32.045, -17.996], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
+			createMarker([-24.107, -22.632], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
+			createMarker([-37.684, -30.037], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells maps and crafting supplies'),
+			createMarker([-56.535, -13.931], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies and fish'),
+			createMarker([-22.837, -20.522], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells armour and crafting supplies'),
+			createMarker([-30.676, -2.681], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells maps, crafting supplies, food, and drink'),
+			createMarker([-14.541, -32.080], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells maps and crafting supplies'),
+			createMarker([-7.559, -40.408], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells maps and crafting supplies'),
+			createMarker([-3.401, -34.077], icons.shopkeeper, 'Tailor', '<h1>Tailor</h1>Sells clothes and crafting supplies. Is also a barber'),
+			createMarker([-8.581, -34.321], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
+	]);
 
 	// Sign Post
-		var signpostIcon = L.icon({
-			iconUrl  : '/files/img/icons/fasttravel.png',
-			iconSize : [27, 34]
-		});
-
-		window.markers['signpost'] = L.layerGroup([
-			// Faroe
-				L.marker([-77.490, 69.829], setMarker(signpostIcon)).bindLabel('Trottheim').bindPopup('<h1>Trottheim</h1>This village was once famed across all of Skellige for the fact that it was inhabited exclusively by women, all their men having died during one raid or another'),
-				L.marker([-77.206, 49.526], setMarker(signpostIcon)).bindLabel('Harviken').bindPopup('<h1>Harviken</h1>Home seat to Clan Dimun, and the location where Holger Blackhand divvies out the loot after every successful raid'),
-			// Hindarsfjall
-				L.marker([-30.031, 99.272], setMarker(signpostIcon)).bindLabel('Larvik').bindPopup('<h1>Larvik</h1>The largest village on Hindarsfjall and home seat to Donar, head of Clan an Hindar. Its inhabitants are just and god-fearing folk, traditionalists strident in their devotion to Freya'),
-				L.marker([-20.838, 86.177], setMarker(signpostIcon)).bindLabel('Freya\'s Garden').bindPopup('<h1>Freya\'s Garden</h1>Garden dedicated to the goddess Freya. Once beautiful and filled with thousands of fragrant blooms and herbs, today it lies abandoned and untended'),
-				L.marker([-25.463, 81.563], setMarker(signpostIcon)).bindLabel('Lofoten').bindPopup('<h1>Lofoten</h1>Once a rich and vibrant village, today Lofoten is a ravaged and crumbling ruin'),
-				L.marker([-29.764, 82.375], setMarker(signpostIcon)).bindLabel('Lofoten Cemetery').bindPopup('<h1>Lofoten Cemetery</h1>The inhabitants of Lofoten often visit this small cemetery to care for the graves of their loved ones and ask Freya for blessings in the afterlife'),
-				L.marker([-33.505, 85.144], setMarker(signpostIcon)).bindLabel('Isolated Hut').bindPopup('<h1>Isolated Hut</h1>They say this was once home to a herbalist who came to the isles from the continent. Unable to find a place in any of the nearby villages, she settled in this seaside hut, where she recieved the occasional visitor in need of magic creams of bandages'),
-				L.marker([-36.668, 91.604], setMarker(signpostIcon)).bindLabel('Lurthen').bindPopup('<h1>Lurthen</h1>Lurthen\'s most famous inhabitant was a certain Peter Pijus, known for the fact that he was able to drink an entire barrel of mead in one go and remain standing'),
-			// An Skellig
-				L.marker([52.882, 46.230], setMarker(signpostIcon)).bindLabel('Trail to Yngvar\'s Fang').bindPopup('<h1>Trail to Yngvar\'s Fang</h1>This is the start of the mountain trail leading to Yngvar\'s Fang, the pride and glory of An Skellig'),
-				L.marker([54.623, 35.376], setMarker(signpostIcon)).bindLabel('Yngvar\'s Fang').bindPopup('<h1>Yngvar\'s Fang</h1>This mountain peak was named after the mythical bear which, according to legend, was defeated by Tyr, the heroic founder of Clan Tuirsearch'),
-				L.marker([50.092, 38.364], setMarker(signpostIcon)).bindLabel('Urialla Harbor').bindPopup('<h1>Urialla Harbor</h1>On account of their mastery of their craft and painstaking attention to detail, the shipwrights working in this harbor are considered the best in the isles'),
-				L.marker([48.444, 27.510], setMarker(signpostIcon)).bindLabel('Bay Of Winds').bindPopup('<h1>Bay Of Winds</h1>Three generations ago this bay was a popular meeting spot for the local youth. Then one night a terrible storm broke out and the sea pounded into the beach, swallowing up several merry-makers and dragging them out to a watery grave'),
-			// Spikeroog
-				L.marker([33.229, -99.470], setMarker(signpostIcon)).bindLabel('Hov').bindPopup('<h1>Hov</h1>Village known throughout all of Skellige for the infamous arena which once hosted fierce fights between the mightiest warriors in the isles'),
-				L.marker([32.380, -113.005], setMarker(signpostIcon)).bindLabel('Svorlag').bindPopup('<h1>Svorlag</h1>The village was founded by the mythical Sove, who killed a terrifying and bloodthirsty chimera on this spot'),
-				L.marker([22.289, -121.509], setMarker(signpostIcon)).bindLabel('Old Watchtower').bindPopup('<h1>Old Watchtower</h1>The ruins of an old watchtower in which, according to legend, a crazed Koviri princess once locked herself up, convinced only a man able to free her from this tower would be fit to be her husband. No one even tried, however, the princess died of old age and the tower fell into disrepair with the passage of time'),
-			// Eastern Islands
-				L.marker([-16.046, -139.482], setMarker(signpostIcon)).bindLabel('The Pali Gap Coast').bindPopup('<h1>The Pali Gap Coast</h1>Elders say an isolated cave on this coast was once used as a retreat by the world\'s most famous bard (before the rise of Dandelion, that is): the great Xirdneh of Zanguebar, renowned from Nazair to the Dragon Mountains for his ferocious lute-strumming'),
-				L.marker([-8.538, -94.922], setMarker(signpostIcon)).bindLabel('Kaer Almhult').bindPopup('<h1>Kaer Almhult</h1>Built centuries ago to serve as the home keep for the kings of Skellige. In practice, however, each ruler preferred to keep to his clan\'s seat, and Kaer Almhult was left unused. Eventually the decision was made to turn it into a prison, and today the fortress is a crumbling ruin'),
-			// Undvik
-				L.marker([-52.456, -110.391], setMarker(signpostIcon)).bindLabel('Marlin Coast').bindPopup('<h1>Marlin Coast</h1>Until quite recently this beach was frequented by fishermen come to fish marlins out of the nearby waters'),
-				L.marker([-58.984, -98.899], setMarker(signpostIcon)).bindLabel('Gull Point').bindPopup('<h1>Gull Point</h1>Sea fowl come from miles around to congregate on this scrap of barren land, mate and lay eggs'),
-				L.marker([-56.377, -113.533], setMarker(signpostIcon)).bindLabel('Dorve Ruins').bindPopup('<h1>Dorve Ruins</h1>Ruins of a village destroyed by the Ice Giant'),
-				L.marker([-61.365, -121.553], setMarker(signpostIcon)).bindLabel('Clan Tordarroch Forge').bindPopup('<h1>Clan Tordarroch Forge</h1>A famous forge where the best tools and weapons in all of Skellige were once made. When the Ice Giant took over the isle, he turned it into his larder'),
-				L.marker([-58.367, -127.529], setMarker(signpostIcon)).bindLabel('Urskar').bindPopup('<h1>Urskar</h1>The villagers here were famous for their love of pickled herring. They ate it for breakfast, dinner, and supper, and even made jams and compotes out of it'),
-				L.marker([-54.801, -135.176], setMarker(signpostIcon)).bindLabel('Abandoned Village').bindPopup('<h1>Abandoned Village</h1>This village\'s residents were forced to abandon it in a hurry when the Ice Giant unexpectedly awoke and decided to make known his wrath'),
-				L.marker([-43.133, -139.219], setMarker(signpostIcon)).bindLabel('Tor Gvalch\'ca').bindPopup('<h1>Tor Gvalch\'ca</h1>An ancient tower which was erected in the days when elves were the unchallenged masters of these lands'),
-			// Ard Skellig
-				L.marker([-70.707, -6.064], setMarker(signpostIcon)).bindLabel('Elverum Lighthouse').bindPopup('<h1>Elverum Lighthouse</h1>The former keeper of this lighthouse was a confirmed eccentric. In addition to caring for the lighthouse, he also wrote poetry and wove carpets, was known to strip naked and run laps around the lighthouse at noon while shouting "sound mind in a sound body" and for breakfast would eat nothing but fish tails'),
-				L.marker([-58.939, -3.252], setMarker(signpostIcon)).bindLabel('Ruined Inn').bindPopup('<h1>Ruined Inn</h1>Ruined and burned-down tavern which once treated locals and travelers to the best roast lamb around'),
-				L.marker([-55.004, -15.029], setMarker(signpostIcon)).bindLabel('Fyresdal').bindPopup('<h1>Fyresdal</h1>Those living here are tough on the outside, but soft and tender within'),
-				L.marker([-63.085, -38.496], setMarker(signpostIcon)).bindLabel('Kaer Muire').bindPopup('<h1>Kaer Muire</h1>This fortress has served as Clan Drummond\'s home base for centuries. the days when it was new and in full repair are a distant memory now'),
-				L.marker([-64.539, -47.329], setMarker(signpostIcon)).bindLabel('Holmstein\'s Port').bindPopup('<h1>Holmstein\'s Port</h1>Piers and docks for the village of Holmstein - Clan Drummond\'s chief port'),
-				L.marker([-54.098, -60.754], setMarker(signpostIcon)).bindLabel('Wild Shore').bindPopup('<h1>Wild Shore</h1>A wild and untamed™ part of the isle\'s coastline. A favourite spot for bandits and lovers'),
-				L.marker([-50.958, -42.935], setMarker(signpostIcon)).bindLabel('Fornhala').bindPopup('<h1>Fornhala</h1>Mysterious abandoned village'),
-				L.marker([-54.763, 12.964], setMarker(signpostIcon)).bindLabel('Distillery').bindPopup('<h1>Distillery</h1>A shroud of secrecy envelops this place. All that is known is that it produces the finest hooch in all of skellige'),
-				L.marker([-56.837, 23.071], setMarker(signpostIcon)).bindLabel('Grotto').bindPopup('<h1>Grotto</h1>An isolated-off locale that can only be reached by boat'),
-				L.marker([-47.145, -6.812], setMarker(signpostIcon)).bindLabel('Palisade').bindPopup('<h1>Palisade</h1>The remnants of the palisade that once marked the border between the territories of Clan Drummond and Clan an Craite'),
-				L.marker([-43.165, -63.677], setMarker(signpostIcon)).bindLabel('Arinbjorn').bindPopup('<h1>Arinbjorn</h1>A village whose calm is only occasionally disturbed by someone slapping another senseless or one comrade breaking a bottle of mead over his mate\'s head'),
-				L.marker([-40.212, -47.900], setMarker(signpostIcon)).bindLabel('Sund').bindPopup('<h1>Sund</h1>Small village whose inhabitant are for the most part shepherds'),
-				L.marker([-36.351, -31.311], setMarker(signpostIcon)).bindLabel('Fayrlund').bindPopup('<h1>Fayrlund</h1>This small village has gained great renown as home to the best hunters in Skellige'),
-				L.marker([-41.311, -17.886], setMarker(signpostIcon)).bindLabel('Boxholm').bindPopup('<h1>Boxholm</h1>Boxholm was once a thriving village serving the nearby fortress, Kaer Nyssen. Today nothing remains of this past glory but a pile of stones, some debris, and fading memories'),
-				L.marker([-29.306, -25.928], setMarker(signpostIcon)).bindLabel('Rannvaig').bindPopup('<h1>Rannvaig</h1>Fifteen years ago, one of the fishermen of Rannvaig bagged an enormous halibut, and from that moment on all the other villagers have devoted their lives to beating his record'),
-				L.marker([-30.827, -4.219], setMarker(signpostIcon)).bindLabel('Blandare').bindPopup('<h1>Blandare</h1>Unusually for a Skellige village, Blandare is located inland, far from any shore. Its inhabitants scratch out a living through mining and shepherding'),
-				L.marker([-32.064, 14.458], setMarker(signpostIcon)).bindLabel('Druids\' Camp').bindPopup('<h1>Druids\' Camp</h1>Camp pitched by druids investigating the magic cataclysm which devastated the nearby woods'),
-				L.marker([-30.940, 25.356], setMarker(signpostIcon)).bindLabel('Redgill').bindPopup('<h1>Redgill</h1>This village\'s inhabitants fled in a panic when a mysterious magic cataclysm struck the surrounding area'),
-				L.marker([-25.642, 7.031], setMarker(signpostIcon)).bindLabel('Abandoned Sawmill').bindPopup('<h1>Abandoned Sawmill</h1>Though located depp in the forest, an ideal place for lumber harvesting, the sawmill now lies abandoned and unused'),
-				L.marker([-22.614, 12.986], setMarker(signpostIcon)).bindLabel('Gedyneith').bindPopup('<h1>Gedyneith</h1>An oak which is sacred to all Skelligers, as it is worshiped both by druids and Freya\'s disciples. The Isle\'s most important ceremonies are held here, including weddings and royal coronations'),
-				L.marker([-22.533, 17.996], setMarker(signpostIcon)).bindLabel('Gedyneith').bindPopup('<h1>Gedyneith</h1>An oak which is sacred to all Skelligers, as it is worshiped both by druids and Freya\'s disciples. The Isle\'s most important ceremonies are held here, including weddings and royal coronations'),
-				L.marker([-13.475, 24.390], setMarker(signpostIcon)).bindLabel('Whale Graveyard').bindPopup('<h1>Whale Graveyard</h1>The isle\'s inhabitants come here and gather bones which they use to build their huts'),
-				L.marker([-21.002, -30.059], setMarker(signpostIcon)).bindLabel('Crossroads').bindPopup('<h1>Crossroads</h1>Fork in the road leading to Kaer Trolde'),
-				L.marker([-16.341, -9.404], setMarker(signpostIcon)).bindLabel('Miners\' Camp').bindPopup('<h1>Miners\' Camp</h1>Small camp which local miners use as a base during their gold prospecting expeditions into the mountains to the north'),
-				L.marker([-14.520, -70.928], setMarker(signpostIcon)).bindLabel('Eldberg Lighthouse').bindPopup('<h1>Eldberg Lighthouse</h1>Lighthouse build on orders of Jarl Skjordal in order to light the sea and route to Arinbjorn'),
-				L.marker([-12.512, 1.626], setMarker(signpostIcon)).bindLabel('Kaer Gelen').bindPopup('<h1>Kaer Gelen</h1>This old fort\'s ruins attract the sort whom one would not want to run into in a dark alley'),
-				L.marker([-7.067, -37.617], setMarker(signpostIcon)).bindLabel('Kaer Trolde Harbor').bindPopup('<h1>Kaer Trolde Harbor</h1>One of the busiest ports in Skellige. Goods from every corner of the world are brought here to be sold and traded'),
-				L.marker([2.636, -38.650], setMarker(signpostIcon)).bindLabel('Bridge to Kaer Trolde').bindPopup('<h1>Bridge to Kaer Trolde</h1>This stone bridge was, according to legend, carved single-handedly by Grymmdjarr, the heroic founder of Clan an Craite'),
-				L.marker([-8.494, -18.171], setMarker(signpostIcon)).bindLabel('Rogne').bindPopup('<h1>Rogne</h1>This mountain settlement is home to tough folk of indomitable spirit'),
-				L.marker([-1.384, -1.956], setMarker(signpostIcon)).bindLabel('Yustianna\'s Grotto').bindPopup('<h1>Yustianna\'s Grotto</h1>Yustianna was a pirate born of a Skelliger from Clan an Craite and a captive woman taken during a raid. In her time she was feared on the Continent from Ofir to Zanguebar. Known for her skill as a navigator and unmatched master of various weapons, she quickly became the terror of the Great Sea, and when she returned to Skellige, they say this cave is where she hid her loot'),
-				L.marker([2.724, 15.029], setMarker(signpostIcon)).bindLabel('Giants\' Toes').bindPopup('<h1>Giants\' Toes</h1>In truth simply a normal rock formation shaped by centuries of wind and water, islanders believe Uroboros punished giants who opposed his will by turning them into these stones'),
-				L.marker([9.947, -22.039], setMarker(signpostIcon)).bindLabel('Ancient Crypt').bindPopup('<h1>Ancient Crypt</h1>Though Skelligers are famed for bravery bordering on madness, there are certain places which even they keep their distance from. This is one of them'),
-		]);
+	markers.signpost = L.layerGroup([
+		// Faroe
+			createMarker([-77.490, 69.829], icons.signpost, 'Trottheim', '<h1>Trottheim</h1>This village was once famed across all of Skellige for the fact that it was inhabited exclusively by women, all their men having died during one raid or another'),
+			createMarker([-77.206, 49.526], icons.signpost, 'Harviken', '<h1>Harviken</h1>Home seat to Clan Dimun, and the location where Holger Blackhand divvies out the loot after every successful raid'),
+		// Hindarsfjall
+			createMarker([-30.031, 99.272], icons.signpost, 'Larvik', '<h1>Larvik</h1>The largest village on Hindarsfjall and home seat to Donar, head of Clan an Hindar. Its inhabitants are just and god-fearing folk, traditionalists strident in their devotion to Freya'),
+			createMarker([-20.838, 86.177], icons.signpost, 'Freya\'s Garden', '<h1>Freya\'s Garden</h1>Garden dedicated to the goddess Freya. Once beautiful and filled with thousands of fragrant blooms and herbs, today it lies abandoned and untended'),
+			createMarker([-25.463, 81.563], icons.signpost, 'Lofoten', '<h1>Lofoten</h1>Once a rich and vibrant village, today Lofoten is a ravaged and crumbling ruin'),
+			createMarker([-29.764, 82.375], icons.signpost, 'Lofoten Cemetery', '<h1>Lofoten Cemetery</h1>The inhabitants of Lofoten often visit this small cemetery to care for the graves of their loved ones and ask Freya for blessings in the afterlife'),
+			createMarker([-33.505, 85.144], icons.signpost, 'Isolated Hut', '<h1>Isolated Hut</h1>They say this was once home to a herbalist who came to the isles from the continent. Unable to find a place in any of the nearby villages, she settled in this seaside hut, where she recieved the occasional visitor in need of magic creams of bandages'),
+			createMarker([-36.668, 91.604], icons.signpost, 'Lurthen', '<h1>Lurthen</h1>Lurthen\'s most famous inhabitant was a certain Peter Pijus, known for the fact that he was able to drink an entire barrel of mead in one go and remain standing'),
+		// An Skellig
+			createMarker([52.882, 46.230], icons.signpost, 'Trail to Yngvar\'s Fang', '<h1>Trail to Yngvar\'s Fang</h1>This is the start of the mountain trail leading to Yngvar\'s Fang, the pride and glory of An Skellig'),
+			createMarker([54.623, 35.376], icons.signpost, 'Yngvar\'s Fang', '<h1>Yngvar\'s Fang</h1>This mountain peak was named after the mythical bear which, according to legend, was defeated by Tyr, the heroic founder of Clan Tuirsearch'),
+			createMarker([50.092, 38.364], icons.signpost, 'Urialla Harbor', '<h1>Urialla Harbor</h1>On account of their mastery of their craft and painstaking attention to detail, the shipwrights working in this harbor are considered the best in the isles'),
+			createMarker([48.444, 27.510], icons.signpost, 'Bay Of Winds', '<h1>Bay Of Winds</h1>Three generations ago this bay was a popular meeting spot for the local youth. Then one night a terrible storm broke out and the sea pounded into the beach, swallowing up several merry-makers and dragging them out to a watery grave'),
+		// Spikeroog
+			createMarker([33.229, -99.470], icons.signpost, 'Hov', '<h1>Hov</h1>Village known throughout all of Skellige for the infamous arena which once hosted fierce fights between the mightiest warriors in the isles'),
+			createMarker([32.380, -113.005], icons.signpost, 'Svorlag', '<h1>Svorlag</h1>The village was founded by the mythical Sove, who killed a terrifying and bloodthirsty chimera on this spot'),
+			createMarker([22.289, -121.509], icons.signpost, 'Old Watchtower', '<h1>Old Watchtower</h1>The ruins of an old watchtower in which, according to legend, a crazed Koviri princess once locked herself up, convinced only a man able to free her from this tower would be fit to be her husband. No one even tried, however, the princess died of old age and the tower fell into disrepair with the passage of time'),
+		// Eastern Islands
+			createMarker([-16.046, -139.482], icons.signpost, 'The Pali Gap Coast', '<h1>The Pali Gap Coast</h1>Elders say an isolated cave on this coast was once used as a retreat by the world\'s most famous bard (before the rise of Dandelion, that is): the great Xirdneh of Zanguebar, renowned from Nazair to the Dragon Mountains for his ferocious lute-strumming'),
+			createMarker([-8.538, -94.922], icons.signpost, 'Kaer Almhult', '<h1>Kaer Almhult</h1>Built centuries ago to serve as the home keep for the kings of Skellige. In practice, however, each ruler preferred to keep to his clan\'s seat, and Kaer Almhult was left unused. Eventually the decision was made to turn it into a prison, and today the fortress is a crumbling ruin'),
+		// Undvik
+			createMarker([-52.456, -110.391], icons.signpost, 'Marlin Coast', '<h1>Marlin Coast</h1>Until quite recently this beach was frequented by fishermen come to fish marlins out of the nearby waters'),
+			createMarker([-58.984, -98.899], icons.signpost, 'Gull Point', '<h1>Gull Point</h1>Sea fowl come from miles around to congregate on this scrap of barren land, mate and lay eggs'),
+			createMarker([-56.377, -113.533], icons.signpost, 'Dorve Ruins', '<h1>Dorve Ruins</h1>Ruins of a village destroyed by the Ice Giant'),
+			createMarker([-61.365, -121.553], icons.signpost, 'Clan Tordarroch Forge', '<h1>Clan Tordarroch Forge</h1>A famous forge where the best tools and weapons in all of Skellige were once made. When the Ice Giant took over the isle, he turned it into his larder'),
+			createMarker([-58.367, -127.529], icons.signpost, 'Urskar', '<h1>Urskar</h1>The villagers here were famous for their love of pickled herring. They ate it for breakfast, dinner, and supper, and even made jams and compotes out of it'),
+			createMarker([-54.801, -135.176], icons.signpost, 'Abandoned Village', '<h1>Abandoned Village</h1>This village\'s residents were forced to abandon it in a hurry when the Ice Giant unexpectedly awoke and decided to make known his wrath'),
+			createMarker([-43.133, -139.219], icons.signpost, 'Tor Gvalch\'ca', '<h1>Tor Gvalch\'ca</h1>An ancient tower which was erected in the days when elves were the unchallenged masters of these lands'),
+		// Ard Skellig
+			createMarker([-70.707, -6.064], icons.signpost, 'Elverum Lighthouse', '<h1>Elverum Lighthouse</h1>The former keeper of this lighthouse was a confirmed eccentric. In addition to caring for the lighthouse, he also wrote poetry and wove carpets, was known to strip naked and run laps around the lighthouse at noon while shouting "sound mind in a sound body" and for breakfast would eat nothing but fish tails'),
+			createMarker([-58.939, -3.252], icons.signpost, 'Ruined Inn', '<h1>Ruined Inn</h1>Ruined and burned-down tavern which once treated locals and travelers to the best roast lamb around'),
+			createMarker([-55.004, -15.029], icons.signpost, 'Fyresdal', '<h1>Fyresdal</h1>Those living here are tough on the outside, but soft and tender within'),
+			createMarker([-63.085, -38.496], icons.signpost, 'Kaer Muire', '<h1>Kaer Muire</h1>This fortress has served as Clan Drummond\'s home base for centuries. the days when it was new and in full repair are a distant memory now'),
+			createMarker([-64.539, -47.329], icons.signpost, 'Holmstein\'s Port', '<h1>Holmstein\'s Port</h1>Piers and docks for the village of Holmstein - Clan Drummond\'s chief port'),
+			createMarker([-54.098, -60.754], icons.signpost, 'Wild Shore', '<h1>Wild Shore</h1>A wild and untamed™ part of the isle\'s coastline. A favourite spot for bandits and lovers'),
+			createMarker([-50.958, -42.935], icons.signpost, 'Fornhala', '<h1>Fornhala</h1>Mysterious abandoned village'),
+			createMarker([-54.763, 12.964], icons.signpost, 'Distillery', '<h1>Distillery</h1>A shroud of secrecy envelops this place. All that is known is that it produces the finest hooch in all of skellige'),
+			createMarker([-56.837, 23.071], icons.signpost, 'Grotto', '<h1>Grotto</h1>An isolated-off locale that can only be reached by boat'),
+			createMarker([-47.145, -6.812], icons.signpost, 'Palisade', '<h1>Palisade</h1>The remnants of the palisade that once marked the border between the territories of Clan Drummond and Clan an Craite'),
+			createMarker([-43.165, -63.677], icons.signpost, 'Arinbjorn', '<h1>Arinbjorn</h1>A village whose calm is only occasionally disturbed by someone slapping another senseless or one comrade breaking a bottle of mead over his mate\'s head'),
+			createMarker([-40.212, -47.900], icons.signpost, 'Sund', '<h1>Sund</h1>Small village whose inhabitant are for the most part shepherds'),
+			createMarker([-36.351, -31.311], icons.signpost, 'Fayrlund', '<h1>Fayrlund</h1>This small village has gained great renown as home to the best hunters in Skellige'),
+			createMarker([-41.311, -17.886], icons.signpost, 'Boxholm', '<h1>Boxholm</h1>Boxholm was once a thriving village serving the nearby fortress, Kaer Nyssen. Today nothing remains of this past glory but a pile of stones, some debris, and fading memories'),
+			createMarker([-29.306, -25.928], icons.signpost, 'Rannvaig', '<h1>Rannvaig</h1>Fifteen years ago, one of the fishermen of Rannvaig bagged an enormous halibut, and from that moment on all the other villagers have devoted their lives to beating his record'),
+			createMarker([-30.827, -4.219], icons.signpost, 'Blandare', '<h1>Blandare</h1>Unusually for a Skellige village, Blandare is located inland, far from any shore. Its inhabitants scratch out a living through mining and shepherding'),
+			createMarker([-32.064, 14.458], icons.signpost, 'Druids\' Camp', '<h1>Druids\' Camp</h1>Camp pitched by druids investigating the magic cataclysm which devastated the nearby woods'),
+			createMarker([-30.940, 25.356], icons.signpost, 'Redgill', '<h1>Redgill</h1>This village\'s inhabitants fled in a panic when a mysterious magic cataclysm struck the surrounding area'),
+			createMarker([-25.642, 7.031], icons.signpost, 'Abandoned Sawmill', '<h1>Abandoned Sawmill</h1>Though located depp in the forest, an ideal place for lumber harvesting, the sawmill now lies abandoned and unused'),
+			createMarker([-22.614, 12.986], icons.signpost, 'Gedyneith', '<h1>Gedyneith</h1>An oak which is sacred to all Skelligers, as it is worshiped both by druids and Freya\'s disciples. The Isle\'s most important ceremonies are held here, including weddings and royal coronations'),
+			createMarker([-22.533, 17.996], icons.signpost, 'Gedyneith', '<h1>Gedyneith</h1>An oak which is sacred to all Skelligers, as it is worshiped both by druids and Freya\'s disciples. The Isle\'s most important ceremonies are held here, including weddings and royal coronations'),
+			createMarker([-13.475, 24.390], icons.signpost, 'Whale Graveyard', '<h1>Whale Graveyard</h1>The isle\'s inhabitants come here and gather bones which they use to build their huts'),
+			createMarker([-21.002, -30.059], icons.signpost, 'Crossroads', '<h1>Crossroads</h1>Fork in the road leading to Kaer Trolde'),
+			createMarker([-16.341, -9.404], icons.signpost, 'Miners\' Camp', '<h1>Miners\' Camp</h1>Small camp which local miners use as a base during their gold prospecting expeditions into the mountains to the north'),
+			createMarker([-14.520, -70.928], icons.signpost, 'Eldberg Lighthouse', '<h1>Eldberg Lighthouse</h1>Lighthouse build on orders of Jarl Skjordal in order to light the sea and route to Arinbjorn'),
+			createMarker([-12.512, 1.626], icons.signpost, 'Kaer Gelen', '<h1>Kaer Gelen</h1>This old fort\'s ruins attract the sort whom one would not want to run into in a dark alley'),
+			createMarker([-7.067, -37.617], icons.signpost, 'Kaer Trolde Harbor', '<h1>Kaer Trolde Harbor</h1>One of the busiest ports in Skellige. Goods from every corner of the world are brought here to be sold and traded'),
+			createMarker([2.636, -38.650], icons.signpost, 'Bridge to Kaer Trolde', '<h1>Bridge to Kaer Trolde</h1>This stone bridge was, according to legend, carved single-handedly by Grymmdjarr, the heroic founder of Clan an Craite'),
+			createMarker([-8.494, -18.171], icons.signpost, 'Rogne', '<h1>Rogne</h1>This mountain settlement is home to tough folk of indomitable spirit'),
+			createMarker([-1.384, -1.956], icons.signpost, 'Yustianna\'s Grotto', '<h1>Yustianna\'s Grotto</h1>Yustianna was a pirate born of a Skelliger from Clan an Craite and a captive woman taken during a raid. In her time she was feared on the Continent from Ofir to Zanguebar. Known for her skill as a navigator and unmatched master of various weapons, she quickly became the terror of the Great Sea, and when she returned to Skellige, they say this cave is where she hid her loot'),
+			createMarker([2.724, 15.029], icons.signpost, 'Giants\' Toes', '<h1>Giants\' Toes</h1>In truth simply a normal rock formation shaped by centuries of wind and water, islanders believe Uroboros punished giants who opposed his will by turning them into these stones'),
+			createMarker([9.947, -22.039], icons.signpost, 'Ancient Crypt', '<h1>Ancient Crypt</h1>Though Skelligers are famed for bravery bordering on madness, there are certain places which even they keep their distance from. This is one of them'),
+	]);
 
 	// Smugglers' Cache
-		var smugglersIcon = L.icon({
-			iconUrl  : '/files/img/icons/smugglers.png',
-			iconSize : [28, 30]
-		});
+	var smugglersGeneric = genericMarkers([
+		[-27.722, -50.098],
+		[-23.080, -57.832],
+		[-18.146, -48.955],
+		[-10.185, -52.163],
+		[-3.996, -61.304],
+		[4.215, -57.173],
+		[12.340, -56.865],
+		[7.885, -68.423],
+		[0.527, -91.846],
+		[-18.355, -82.266],
+		[-24.327, -80.771],
+		[-21.576, -105.469],
+		[-16.594, -121.992],
+		[1.099, -119.971],
+		[12.426, -101.250],
+		[21.943, -72.949],
+		[36.809, -62.007],
+		[36.809, -30.366],
+		[29.075, -33.706],
+		[16.720, -35.288],
+		[17.811, -24.829],
+		[24.767, -10.942],
+		[15.538, -3.560],
+		[32.027, 8.833],
+		[37.788, 47.813],
+		[36.527, 43.154],
+		[37.719, 33.926],
+		[21.617, 48.691],
+		[25.919, 84.463],
+		[-7.362, 28.389],
+		[2.328, 27.686],
+		[-6.446, 38.848],
+		[2.153, 37.793],
+		[-10.617, 47.417],
+		[-11.092, 59.985],
+		[-11.092, 70.884],
+		[-26.195, 60.029],
+		[-56.705, 79.805],
+		[-60.759, 40.430],
+		[-62.042, 25.269],
+		[-66.496, 3.120],
+		[-68.544, 8.657],
+		[-77.332, 13.623],
+		[-76.321, -22.148],
+		[-77.351, -47.065],
+		[-78.853, -121.729],
+		[-74.068, -79.365],
+		[-70.613, -55.986],
+		[-66.896, -83.145],
+		[-57.374, -78.311],
+		[-41.079, -76.421],
+		[-41.673, -92.505],
+		[-37.125, -97.383],
+		[-36.510, -82.046],
+		[61.186, -90.264],
+		[53.697, -55.371],
+		[52.107, -22.500],
+		[56.023, -8.877],
+	], icons.smugglers, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
 
-		var smugglersGeneric = genericMarkers([
-			[-27.722, -50.098],
-			[-23.080, -57.832],
-			[-18.146, -48.955],
-			[-10.185, -52.163],
-			[-3.996, -61.304],
-			[4.215, -57.173],
-			[12.340, -56.865],
-			[7.885, -68.423],
-			[0.527, -91.846],
-			[-18.355, -82.266],
-			[-24.327, -80.771],
-			[-21.576, -105.469],
-			[-16.594, -121.992],
-			[1.099, -119.971],
-			[12.426, -101.250],
-			[21.943, -72.949],
-			[36.809, -62.007],
-			[36.809, -30.366],
-			[29.075, -33.706],
-			[16.720, -35.288],
-			[17.811, -24.829],
-			[24.767, -10.942],
-			[15.538, -3.560],
-			[32.027, 8.833],
-			[37.788, 47.813],
-			[36.527, 43.154],
-			[37.719, 33.926],
-			[21.617, 48.691],
-			[25.919, 84.463],
-			[-7.362, 28.389],
-			[2.328, 27.686],
-			[-6.446, 38.848],
-			[2.153, 37.793],
-			[-10.617, 47.417],
-			[-11.092, 59.985],
-			[-11.092, 70.884],
-			[-26.195, 60.029],
-			[-56.705, 79.805],
-			[-60.759, 40.430],
-			[-62.042, 25.269],
-			[-66.496, 3.120],
-			[-68.544, 8.657],
-			[-77.332, 13.623],
-			[-76.321, -22.148],
-			[-77.351, -47.065],
-			[-78.853, -121.729],
-			[-74.068, -79.365],
-			[-70.613, -55.986],
-			[-66.896, -83.145],
-			[-57.374, -78.311],
-			[-41.079, -76.421],
-			[-41.673, -92.505],
-			[-37.125, -97.383],
-			[-36.510, -82.046],
-			[61.186, -90.264],
-			[53.697, -55.371],
-			[52.107, -22.500],
-			[56.023, -8.877],
-		], smugglersIcon, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
-
-		window.markers['smugglers'] = L.layerGroup($.merge(smugglersGeneric, [
-			// No custom markers needed
-		]));
+	markers.smugglers = L.layerGroup($.merge(smugglersGeneric, [
+		// No custom markers needed
+	]));
 
 	// Spoils of War
-		var spoilsIcon = L.icon({
-			iconUrl  : '/files/img/icons/spoils.png',
-			iconSize : [25, 28]
-		});
-
-		window.markers['spoils'] = L.layerGroup(genericMarkers([
-			[29.650, -63.896],
-			[21.412, -47.285],
-			[-50.709, 43.550],
-			[-69.396, 25.356],
-			[-77.466, -63.193],
-			[-16.426, -144.009],
-			[-20.879, -158.467],
-			[57.891, -28.564],
-		], spoilsIcon, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'));
+	markers.spoils = L.layerGroup(genericMarkers([
+		[29.650, -63.896],
+		[21.412, -47.285],
+		[-50.709, 43.550],
+		[-69.396, 25.356],
+		[-77.466, -63.193],
+		[-16.426, -144.009],
+		[-20.879, -158.467],
+		[57.891, -28.564],
+	], icons.spoils, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'));
 
 	window.allLayers = [
-		window.markers['abandoned'],
-		window.markers['alchemy'],
-		window.markers['armourer'],
-		window.markers['armourerstable'],
-		window.markers['banditcamp'],
-		window.markers['barber'],
-		window.markers['blacksmith'],
-		window.markers['brothel'],
-		window.markers['entrance'],
-		window.markers['grindstone'],
-		window.markers['guarded'],
-		window.markers['gwent'],
-		window.markers['harbor'],
-		window.markers['herbalist'],
-		window.markers['hidden'],
-		window.markers['innkeep'],
-		window.markers['monsterden'],
-		window.markers['monsternest'],
-		window.markers['notice'],
-		window.markers['pid'],
-		window.markers['pop'],
-		window.markers['poi'],
-		window.markers['shopkeeper'],
-		window.markers['signpost'],
-		window.markers['smugglers'],
-		window.markers['spoils']
+		markers.abandoned,
+		markers.alchemy,
+		markers.armourer,
+		markers.armourerstable,
+		markers.banditcamp,
+		markers.barber,
+		markers.blacksmith,
+		markers.brothel,
+		markers.entrance,
+		markers.grindstone,
+		markers.guarded,
+		markers.gwent,
+		markers.harbor,
+		markers.herbalist,
+		markers.hidden,
+		markers.innkeep,
+		markers.monsterden,
+		markers.monsternest,
+		markers.notice,
+		markers.pid,
+		markers.pop,
+		markers.poi,
+		markers.shopkeeper,
+		markers.signpost,
+		markers.smugglers,
+		markers.spoils
 	];
-});
+}());
+

--- a/files/js/mapdata-skellige.js
+++ b/files/js/mapdata-skellige.js
@@ -5,569 +5,1091 @@
 	window.map_center = [-35, -10];
 	window.map_mZoom  = 6;
 
-	var icons = window.icons;
-	var markers = window.markers;
-
+	processData({
 	// Abandoned Site
-	markers.abandoned = L.layerGroup(genericMarkers([
-		// Hindarsfjall
-			[-35.996, 92.439],
-			[-32.916, 85.562],
-		// Ard Skellig
-			[-45.522, -49.570],
-			[-23.745, -19.841],
-	], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more'));
+		abandoned: [{
+			coords: [
+				// Hindarsfjall
+					[-35.996, 92.439],
+					[-32.916, 85.562],
+				// Ard Skellig
+					[-45.522, -49.570],
+					[-23.745, -19.841],
+			],
+			label: 'Abandoned Site',
+			popup: 'A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more'
+		}],
 
 	// Alchemy Supplies
-	markers.alchemy = L.layerGroup([
-		createMarker([-20.468, 93.318], icons.alchemy, 'Alchemy Supplies', '<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
-		createMarker([-28.208, -26.147], icons.alchemy, 'Alchemy Supplies', '<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
-		createMarker([-19.705, 17.314], icons.alchemy, 'Gremist', '<h1>Gremist</h1>\'Practicum in Advanced Alchemy\' (lvl 24) Quest'),
-	]);
+		alchemy: [{
+			coords: [[-20.468, 93.318]],
+			label: 'Alchemy Supplies',
+			popup: 'Here you can buy alchemy ingredients'
+		}, {
+			coords: [[-28.208, -26.147]],
+			label: 'Alchemy Supplies',
+			popup: 'Here you can buy alchemy ingredients'
+		}, {
+			coords: [[-19.705, 17.314]],
+			label: 'Gremist',
+			popup: '\'Practicum in Advanced Alchemy\' (lvl 24) Quest'
+		}],
 
 	// Armourer
-	markers.armourer = L.layerGroup([
-		// Hindarsfjall
-			createMarker([-29.037, 98.569], icons.armourer, 'Amateur Armorer', '<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// An Skellig
-			createMarker([49.253, 39.243], icons.armourer, 'Amateur Armorer', '<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// Ard Skellig
-			createMarker([-62.492, -37.705], icons.armourer, 'Journeyman Armorer', '<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			createMarker([2.965, -40.210], icons.armourer, 'Journeyman Armorer', '<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-	]);
+		armourer: [{ // Hindarsfjall
+			coords: [[-29.037, 98.569]],
+			label: 'Amateur Armorer',
+			popup: 'Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // An Skellig
+			coords: [[49.253, 39.243]],
+			label: 'Amateur Armorer',
+			popup: 'Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // Ard Skellig
+			coords: [[-62.492, -37.705]],
+			label: 'Journeyman Armorer',
+			popup: 'Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, {
+			coords: [[2.965, -40.210]],
+			label: 'Journeyman Armorer',
+			popup: 'Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}],
 
 	// Armourer's Table
-	markers.armourerstable = L.layerGroup(genericMarkers([
-		// Hindarsfjall
-			[-28.159, 101.851],
-			[-28.825, 98.062],
-			[-32.806, 84.771],
-		// An Skellig
-			[50.247, 39.529],
-		// Spikeroog
-			[33.560, -111.445],
-		// Ard Skellig
-			[-62.127, -37.375],
-			[-39.455, -63.127],
-			[2.826, -40.997],
-	], icons.armourerstable, 'Armorer\'s Table', '<h1>Armorer\'s Table</h1>Armorer\'s tables grant your gear increased armor for a limited duration'));
+		armourerstable: [{
+			coords: [
+				// Hindarsfjall
+				[-28.159, 101.851],
+				[-28.825, 98.062],
+				[-32.806, 84.771],
+				// An Skellig
+				[50.247, 39.529],
+				// Spikeroog
+				[33.560, -111.445],
+				// Ard Skellig
+				[-62.127, -37.375],
+				[-39.455, -63.127],
+				[2.826, -40.997],
+			],
+			label: 'Armorer\'s Table',
+			popup: 'Armorer\'s tables grant your gear increased armor for a limited duration'
+		}],
 
 	// Bandit Camp
-	markers.banditcamp = L.layerGroup(genericMarkers([
-		// Spikeroog
-			[21.861, -121.047],
-		// Ard Skellig
-			[-61.260, -50.669],
-			[-29.459, -17.886],
-			[-14.562, 27.861],
-			[5.616, 15.557],
-		// Sea
-			[20.797, 38.848],
-	], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here'));
+		banditcamp: [{
+			coords: [
+				// Spikeroog
+				[21.861, -121.047],
+				// Ard Skellig
+				[-61.260, -50.669],
+				[-29.459, -17.886],
+				[-14.562, 27.861],
+				[5.616, 15.557],
+				// Sea
+				[20.797, 38.848],
+			],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here'
+		}],
 
 	// Barber
-	markers.barber = L.layerGroup(genericMarkers([
-		// Spikeroog
-			[31.072, -111.973],
-			[-3.601, -34.277],
-	], icons.barber, 'Barber', '<h1>Barber</h1>Visit barbers for a shave or a new haircut'));
+		barber: [{
+			coords: [
+				// Spikeroog
+				[31.072, -111.973],
+				[-3.601, -34.277],
+			],
+			label: 'Barber',
+			popup: 'Visit barbers for a shave or a new haircut'
+		}],
 
 	// Blacksmith
-	markers.blacksmith = L.layerGroup([
-		// Faroe
-			createMarker([-77.390, 50.142], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// Hindarsfjall
-			createMarker([-28.613, 102.458], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// An Skellig
-			createMarker([50.641, 38.013], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// Spikeroog
-			createMarker([33.101, -111.709], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// Ard Skellig
-			createMarker([-62.007, -37.903], icons.blacksmith, 'Journeyman Blacksmith', '<h1>Journeyman Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			createMarker([-39.504, -63.647], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			createMarker([-37.265, -32.014], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			createMarker([-56.945, -15.513], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			createMarker([3.141, -40.649], icons.blacksmith, 'Journeyman Blacksmith', '<h1>Journeyman Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-	]);
+		blacksmith: [{ // Faroe
+			coords: [[-77.390, 50.142]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // Hindarsfjall
+			coords: [[-28.613, 102.458]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // An Skellig
+			coords: [[50.641, 38.013]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // Spikeroog
+			coords: [[33.101, -111.709]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // Ard Skellig
+			coords: [[-62.007, -37.903]],
+			label: 'Journeyman Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, {
+			coords: [[-39.504, -63.647]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, {
+			coords: [[-37.265, -32.014]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, {
+			coords: [[-56.945, -15.513]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, {
+			coords: [[3.141, -40.649]],
+			label: 'Journeyman Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}],
 
 	// Brothel
-	markers.brothel = L.layerGroup([]);
+		brothel: [],
 
 	// Entrance
 		// todo, entrance to what?
-	markers.entrance = L.layerGroup([
-		// Faroe
-			createMarker([-78.469, 43.484], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-77.250, 44.187], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// Hindarsfjall
-			createMarker([-17.036, 91.230], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-18.750, 88.022], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-18.813, 108.677], icons.entrance, 'Underwater Cave', '<h1>Underwater Cave</h1>Underwater entrance to cave'),
-			createMarker([-25.205, 92.769], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-28.033, 89.912], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-29.955, 94.131], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// An Skellig
-			createMarker([50.317, 33.289], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// Spikeroog
-			createMarker([17.225, -123.640], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// Eastern Islands
-			createMarker([-15.623, -139.043], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// Undvik
-			createMarker([-51.727, -134.517], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-60.791, -127.375], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-61.470, -122.278], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-56.933, -124.343], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-59.108, -111.313], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// Ard Skellig
-			createMarker([-71.124, -8.525], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-69.756, -8.503], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-69.938, -23.906], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-52.389, -42.473], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-45.722, -30.256], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-23.322, -67.983], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-18.396, -38.804], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-56.801, 23.379], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-54.581, 12.964], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-47.145, 17.468], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-44.072, 6.350], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-12.897, -13.667], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-13.240, -27.598], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-20.056, 17.446], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-1.801, -1.099], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([9.926, -22.168], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-	]);
+		entrance: [{ // Faroe
+			coords: [[-78.469, 43.484]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-77.250, 44.187]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // Hindarsfjall
+			coords: [[-17.036, 91.230]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-18.750, 88.022]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-18.813, 108.677]],
+			label: 'Underwater Cave',
+			popup: 'Underwater entrance to cave'
+		}, {
+			coords: [[-25.205, 92.769]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-28.033, 89.912]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-29.955, 94.131]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // An Skellig
+			coords: [[50.317, 33.289]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // Spikeroog
+			coords: [[17.225, -123.640]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // Eastern Islands
+			coords: [[-15.623, -139.043]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // Undvik
+			coords: [[-51.727, -134.517]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-60.791, -127.375]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-61.470, -122.278]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-56.933, -124.343]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-59.108, -111.313]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // Ard Skellig
+			coords: [[-71.124, -8.525]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-69.756, -8.503]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-69.938, -23.906]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-52.389, -42.473]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-45.722, -30.256]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-23.322, -67.983]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-18.396, -38.804]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-56.801, 23.379]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-54.581, 12.964]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-47.145, 17.468]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-44.072, 6.350]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-12.897, -13.667]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-13.240, -27.598]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-20.056, 17.446]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-1.801, -1.099]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[9.926, -22.168]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}],
 
 	// Grindstone
-	markers.grindstone = L.layerGroup(genericMarkers([
-		// Faroe
-			[-77.355, 50.647],
-		// Hindarsfjall
-			[-28.420, 102.119],
-			[-28.929, 97.754],
-			[-32.990, 84.902],
-		// An Skellig
-			[50.499, 39.836],
-		// Spikeroog
-			[33.340, -111.357],
-		// Ard Skellig
-			[-62.390, -37.156],
-			[-39.317, -62.996],
-			[-23.564, -20.522],
-			[2.526, -40.957],
-	], icons.grindstone, 'Grindstone', '<h1>Grindstone</h1>A blade sharpened here will deal more damage'));
+		grindstone: [{
+			coords: [
+				// Faroe
+				[-77.355, 50.647],
+				// Hindarsfjall
+				[-28.420, 102.119],
+				[-28.929, 97.754],
+				[-32.990, 84.902],
+				// An Skellig
+				[50.499, 39.836],
+				// Spikeroog
+				[33.340, -111.357],
+				// Ard Skellig
+				[-62.390, -37.156],
+				[-39.317, -62.996],
+				[-23.564, -20.522],
+				[2.526, -40.957],
+			],
+			label: 'Grindstone',
+			popup: 'A blade sharpened here will deal more damage'
+		}],
 
 	// Guarded Treasure
-	var guardedGeneric = genericMarkers([
-		// Faroe
-			[-75.958, 43.835],
-		// Hindarsfjall
-			[-22.472, 85.386],
-		// Undvik
-			[-46.134, -120.586],
-			[-69.877, -160.225],
-		// Ard Skellig
-			[-70.873, -5.625],
-			[-66.531, -15.908],
-			[-53.278, -63.413],
-			[-46.815, -37.639],
-			[-21.678, -32.717],
-			[-26.392, -5.142],
-			[-13.625, -43.506],
-			[-23.765, 23.291],
-			[5.791, -17.754],
-		// Sea
-			[28.111, 91.406],
-			[-73.788, 20.347],
-			[-70.215, 35.552],
-			[53.801, -64.336],
-			[55.279, -40.869],
-			[55.826, -30.674],
-			[59.623, -26.279],
-			[61.058, -17.754],
-			[57.845, -1.670],
-	], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
-
-	markers.guarded = L.layerGroup($.merge(guardedGeneric, [
-		// No custom markers needed
-	]));
+		guarded: [{
+			coords: [
+				// Faroe
+				[-75.958, 43.835],
+				// Hindarsfjall
+				[-22.472, 85.386],
+				// Undvik
+				[-46.134, -120.586],
+				[-69.877, -160.225],
+				// Ard Skellig
+				[-70.873, -5.625],
+				[-66.531, -15.908],
+				[-53.278, -63.413],
+				[-46.815, -37.639],
+				[-21.678, -32.717],
+				[-26.392, -5.142],
+				[-13.625, -43.506],
+				[-23.765, 23.291],
+				[5.791, -17.754],
+				// Sea
+				[28.111, 91.406],
+				[-73.788, 20.347],
+				[-70.215, 35.552],
+				[53.801, -64.336],
+				[55.279, -40.869],
+				[55.826, -30.674],
+				[59.623, -26.279],
+				[61.058, -17.754],
+				[57.845, -1.670],
+			],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster guards a valuable cache here'
+		}],
 
 	// Gwent Player
-	markers.gwent = L.layerGroup([
-		// Faroe
-			createMarker([-77.455, 49.227], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-77.350, 50.242], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-		// Hindarsfjall
-			createMarker([-29.206, 99.662], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-28.985, 100.993], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-28.513, 102.658], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-28.937, 98.769], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-		// An Skellig
-			createMarker([50.701, 38.203], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([50.669, 40.630], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([49.313, 39.443], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-		// Spikeroog
-			createMarker([33.201, -111.909], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([31.360, -110.856], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([31.361, -112.799], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-		// Ard Skellig
-			createMarker([-62.442, -37.585], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-61.917, -37.753], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-64.003, -47.744], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-42.031, -61.873], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-39.404, -63.487], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-37.165, -31.814], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-37.584, -29.837], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-56.435, -13.731], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-56.845, -15.313], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([3.085, -40.010], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([3.241, -40.449], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-30.576, -2.481], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-5.997, -34.407], icons.gwent, 'Gwent Player', '<h1>Herbalist Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-3.194, -35.967], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-	]);
+		gwent: [{ // Faroe
+			coords: [[-77.455, 49.227]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-77.350, 50.242]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, { // Hindarsfjall
+			coords: [[-29.206, 99.662]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-28.985, 100.993]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-28.513, 102.658]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-28.937, 98.769]],
+			label: 'Gwent Player',
+			popupTitle: 'Armorer Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, { // An Skellig
+			coords: [[50.701, 38.203]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[50.669, 40.630]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[49.313, 39.443]],
+			label: 'Gwent Player',
+			popupTitle: 'Armorer Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, { // Spikeroog
+			coords: [[33.201, -111.909]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[31.360, -110.856]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[31.361, -112.799]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, { // Ard Skellig
+			coords: [[-62.442, -37.585]],
+			label: 'Gwent Player',
+			popupTitle: 'Armorer Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-61.917, -37.753]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-64.003, -47.744]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-42.031, -61.873]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-39.404, -63.487]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-37.165, -31.814]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-37.584, -29.837]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-56.435, -13.731]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-56.845, -15.313]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[3.085, -40.010]],
+			label: 'Gwent Player',
+			popupTitle: 'Armorer Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[3.241, -40.449]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-30.576, -2.481]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-5.997, -34.407]],
+			label: 'Gwent Player',
+			popupTitle: 'Herbalist Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-3.194, -35.967]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}],
 
 	// Harbor
-	markers.harbor = L.layerGroup(genericMarkers([
-		[-6.075, -40.496],
-		[11.265, -23.005],
-		[-28.498, -28.696],
-		[-38.514, -65.544],
-		[-23.403, -75.388],
-		[-50.972, -106.721],
-		[-43.628, -116.301],
-		[-64.053, -52.207],
-		[-76.496, 53.394],
-		[-58.101, -12.349],
-		[-59.955, -2.944],
-		[-57.065, 25.796],
-		[-25.681, 100.767],
-		[-31.915, 26.938],
-		[47.725, 38.628],
-		[32.769, -107.974],
-		[-14.477, -141.064],
-	], icons.harbor, 'Harbor', '<h1>Harbor</h1>A place where you can find a boat, boats will respawn here'));
+		harbor: [{
+			coords: [
+				[-6.075, -40.496],
+				[11.265, -23.005],
+				[-28.498, -28.696],
+				[-38.514, -65.544],
+				[-23.403, -75.388],
+				[-50.972, -106.721],
+				[-43.628, -116.301],
+				[-64.053, -52.207],
+				[-76.496, 53.394],
+				[-58.101, -12.349],
+				[-59.955, -2.944],
+				[-57.065, 25.796],
+				[-25.681, 100.767],
+				[-31.915, 26.938],
+				[47.725, 38.628],
+				[32.769, -107.974],
+				[-14.477, -141.064],
+			],
+			label: 'Harbor',
+			popup: 'A place where you can find a boat, boats will respawn here'
+		}],
 
 	// Herbalist
-	var herbalistGeneric = genericMarkers([
-		// Ard Skellig
-			[-32.473, 14.722],
-			[-6.097, -34.607],
-	], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>Here you can buy alchemy ingredients');
-
-	markers.herbalist = L.layerGroup($.merge(herbalistGeneric, [
-		// No custom markers needed
-	]));
-
+		herbalist: [{
+			coords: [
+				// Ard Skellig
+					[-32.473, 14.722],
+					[-6.097, -34.607],
+			],
+			label: 'Herbalist',
+			popup: 'Here you can buy alchemy ingredients'
+		}],
 
 	// Hidden Treasure
-	var hiddenGeneric = genericMarkers([
-		// Faroe
-			[-78.469, 42.957],
-		// An Skellig
-			[46.905, 46.582],
-		// Spikeroog
-			[26.274, -104.238],
-			[27.020, -95.977],
-		// Undvik
-			[-46.073, -133.835],
-			[-55.937, -121.223],
-			[-56.317, -150.073],
-			[-45.568, -102.327],
-		// Eastern Islands
-			[-12.039, -98.701],
-		// Ard Skellig
-			[-72.262, 5.317],
-			[-58.825, -3.735],
-			[-32.287, -50.757],
-			[-40.028, -18.083],
-			[-38.857, -26.543],
-			[-24.127, -69.829],
-			[-36.315, 0.264],
-			[-21.739, 30.498],
-			[2.021, -21.709],
-		// Sea
-			[4.083, -78.223],
-			[31.541, -65.566],
-			[38.788, -21.533],
-			[-65.658, 41.396],
-			[-78.044, -41.968],
-			[63.666, -88.154],
-			[50.373, -7.515],
-	], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
-
-	markers.hidden = L.layerGroup($.merge(hiddenGeneric, [
-		// No custom markers needed
-	]));
+		hidden: [{
+			coords: [
+				// Faroe
+				[-78.469, 42.957],
+				// An Skellig
+				[46.905, 46.582],
+				// Spikeroog
+				[26.274, -104.238],
+				[27.020, -95.977],
+				// Undvik
+				[-46.073, -133.835],
+				[-55.937, -121.223],
+				[-56.317, -150.073],
+				[-45.568, -102.327],
+				// Eastern Islands
+				[-12.039, -98.701],
+				// Ard Skellig
+				[-72.262, 5.317],
+				[-58.825, -3.735],
+				[-32.287, -50.757],
+				[-40.028, -18.083],
+				[-38.857, -26.543],
+				[-24.127, -69.829],
+				[-36.315, 0.264],
+				[-21.739, 30.498],
+				[2.021, -21.709],
+				// Sea
+				[4.083, -78.223],
+				[31.541, -65.566],
+				[38.788, -21.533],
+				[-65.658, 41.396],
+				[-78.044, -41.968],
+				[63.666, -88.154],
+				[50.373, -7.515],
+			],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods'
+		}],
 
 	// Innkeep
-	markers.innkeep = L.layerGroup([
-		// Faroe
-			createMarker([-77.485, 49.007], icons.innkeep, 'Harviken Inn', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-		// Hindarsfjall
-			createMarker([-29.075, 100.723], icons.innkeep, 'House of Warriors', '<h1>Innkeep</h1>Sells Food, and drink'),
-		// An Skellig
-			createMarker([50.569, 40.430], icons.innkeep, 'Urialla Harbour Inn', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-		// Spikeroog
-			createMarker([31.241, -113.049], icons.innkeep, 'Svorlag Inn', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-		// Ard Skellig
-			createMarker([-42.131, -62.073], icons.innkeep, 'Arinbjorn Inn', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-			createMarker([-3.294, -36.167], icons.innkeep, 'The New Port', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-	]);
+		innkeep: [{ // Faroe
+			coords: [[-77.485, 49.007]],
+			label: 'Harviken Inn',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, food, and drink'
+		}, { // Hindarsfjall
+			coords: [[-29.075, 100.723]],
+			label: 'House of Warriors',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Food, and drink'
+		}, { // An Skellig
+			coords: [[50.569, 40.430]],
+			label: 'Urialla Harbour Inn',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, food, and drink'
+		}, { // Spikeroog
+			coords: [[31.241, -113.049]],
+			label: 'Svorlag Inn',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, food, and drink'
+		}, { // Ard Skellig
+			coords: [[-42.131, -62.073]],
+			label: 'Arinbjorn Inn',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, food, and drink'
+		}, {
+			coords: [[-3.294, -36.167]],
+			label: 'The New Port',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, food, and drink'
+		}],
 
 	// Monster Den
-	var monsterdenGeneric = genericMarkers([
-		// Faroe
-			[-78.587, 68.071],
-			[-77.133, 56.646],
-		// Ard Skellig
-			[-50.078, -33.245],
-			[-10.401, 1.758],
-			[-5.922, 8.262],
-			[-2.416, -21.841],
-	], icons.monsterden, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby');
-
-	markers.monsterden = L.layerGroup($.merge(monsterdenGeneric, [
-		// No custom markers needed
-	]));
+		monsterden: [{
+			coords: [
+				// Faroe
+				[-78.587, 68.071],
+				[-77.133, 56.646],
+				// Ard Skellig
+				[-50.078, -33.245],
+				[-10.401, 1.758],
+				[-5.922, 8.262],
+				[-2.416, -21.841],
+			],
+			label: 'Monster Den',
+			popup: 'Monster-infested location. A constant worry for those living nearby'
+		}],
 
 	// Monster Nest
-	var monsternestGeneric = genericMarkers([
-		// An Skellig
-			[50.458, 26.521],
-		// Ard Skellig
-			[-59.074, -24.521],
-			[-59.120, -4.131],
-			[-24.827, -29.070],
-			[-23.544, -37.551],
-	], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
-
-	markers.monsternest = L.layerGroup($.merge(monsternestGeneric, [
-		// No custom markers needed
-	]));
+		monsternest: [{
+			coords: [
+				// An Skellig
+				[50.458, 26.521],
+				// Ard Skellig
+				[-59.074, -24.521],
+				[-59.120, -4.131],
+				[-24.827, -29.070],
+				[-23.544, -37.551],
+			],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs'
+		}],
 
 	// Notice Board
-	markers.notice = L.layerGroup(genericMarkers([
-		// Hindarsfjall
-			[-28.343, 100.239],
-		// Spikeroog
-			[31.996, -111.313],
-		// Ard Skellig
-			[-63.095, -43.594],
-			[-42.844, -62.996],
-			[-27.547, -25.005],
-			[-55.454, -15.337],
-			[-30.468, -1.890],
-			[-6.905, -35.178],
-	], icons.notice, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
+		notice: [{
+			coords: [
+				// Hindarsfjall
+				[-28.343, 100.239],
+				// Spikeroog
+				[31.996, -111.313],
+				// Ard Skellig
+				[-63.095, -43.594],
+				[-42.844, -62.996],
+				[-27.547, -25.005],
+				[-55.454, -15.337],
+				[-30.468, -1.890],
+				[-6.905, -35.178],
+			],
+			label: 'Notice Board',
+			popup: 'Here you can find monster contracts and announcements about matters of local concern'
+		}],
 
 	// Person in Distress
-	var pidGeneric = genericMarkers([
-		[-33.633, -40.298],
-		[-38.994, -6.372],
-	], icons.pid, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance');
-
-	markers.pid = L.layerGroup($.merge(pidGeneric, [
-		// No custom markers needed
-	]));
+		pid: [{
+			coords: [
+				[-33.633, -40.298],
+				[-38.994, -6.372],
+			],
+			label: 'Person(s) in Distress',
+			popup: 'There\'s a person or a group of people here in need of assitance'
+		}],
 
 	// Place of Power
 		//todo get all place of power types
-	markers.pop = L.layerGroup([
-		// Faroe
-			createMarker([-76.851, 40.891], icons.pop, 'Place of Power', '<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'),
-		// An Skellig
-			createMarker([54.496, 35.903], icons.pop, 'Place of Power', '<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'),
-		// Spikeroog
-			createMarker([34.343, -120.564], icons.pop, 'Place of Power', '<h1>Place of Power - Igni</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'),
-		// Ard Skellig
-			createMarker([-57.350, -48.604], icons.pop, 'Place of Power', '<h1>Place of Power - Axii</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			createMarker([-24.667, -36.497], icons.pop, 'Place of Power', '<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			createMarker([-32.194, 15.710], icons.pop, 'Place of Power', '<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			createMarker([4.784, -42.451], icons.pop, 'Place of Power', '<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			createMarker([-21.576, 29.795], icons.pop, 'Place of Power', '<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			createMarker([4.390, -25.708], icons.pop, 'Place of Power', '<h1>Place of Power - Todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-	]);
+		pop: [{ // Faroe
+			coords: [[-76.851, 40.891]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Yrden',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'
+		}, { // An Skellig
+			coords: [[54.496, 35.903]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Quen',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'
+		}, { // Spikeroog
+			coords: [[34.343, -120.564]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Igni',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'
+		}, { // Ard Skellig
+			coords: [[-57.350, -48.604]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Axii',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, {
+			coords: [[-24.667, -36.497]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Todo',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, {
+			coords: [[-32.194, 15.710]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Todo',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, {
+			coords: [[4.784, -42.451]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Todo',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, {
+			coords: [[-21.576, 29.795]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Todo',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, {
+			coords: [[4.390, -25.708]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Todo',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}],
 
 	// Point of Interest
-
-		markers.poi = L.layerGroup([
-			// Faroe
-				createMarker([-76.985, 57.788], icons.poi, 'Jutta An Dimun', '<h1>Jutta An Dimun</h1>todo'), //double check this
-			// Ard Skellig
-				createMarker([-58.344, -2.549], icons.poi, 'Ursine Steel Sword', '<h1>Ursine Steel Sword Diagram</h1>In a chest in the basement of this ruin'),
-				createMarker([-40.112, -14.546], icons.poi, 'Griffin Steel Sword Mastercrafted', '<h1>Griffin Steel Sword Mastercrafted</h1>'),
-				createMarker([-1.274, -11.931], icons.poi, 'Enhanced Ursine Gauntlets', '<h1>Enhanced Ursine Gauntlets Diagram</h1>'),
-				createMarker([8.559, 13.733], icons.poi, 'Superior Griffin Armour Set', '<h1>Superior Griffin Armour Set Diagrams</h1>Armor, boots, gauntlets, trousers'),
+		poi: [{ // Faroe
+			coords: [[-76.985, 57.788]],
+			label: 'Jutta An Dimun',
+			popup: 'todo'
+		}, {
+					// Ard Skellig
+			coords: [[-58.344, -2.549]],
+			label: 'Ursine Steel Sword',
+			popupTitle: 'Ursine Steel Sword Diagram',
+			popup: 'In a chest in the basement of this ruin'
+		}, {
+			coords: [[-40.112, -14.546]],
+			label: 'Griffin Steel Sword Mastercrafted',
+			popup: ''
+		}, {
+			coords: [[-1.274, -11.931]],
+			label: 'Enhanced Ursine Gauntlets',
+			popupTitle: 'Enhanced Ursine Gauntlets Diagram',
+			popup: ''
+		}, {
+			coords: [[8.559, 13.733]],
+			label: 'Superior Griffin Armour Set',
+			popupTitle: 'Superior Griffin Armour Set Diagrams',
+			popup: 'Armor, boots, gauntlets, trousers'
+		}],
 				
-		]);
 
 	// Shopkeeper
-	markers.shopkeeper = L.layerGroup([
-		// Hindarsfjall
-			createMarker([-29.306, 99.492], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies and fish'),
-		// Spikeroog
-			createMarker([31.260, -111.006], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies and fish'),
-		// Ard Skellig
-			createMarker([-64.063, -47.944], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells maps, crafting supplies, fish and \'Mastercrafted Cavalry Saddle\' (+75)'),
-			createMarker([-60.555, -51.416], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-			createMarker([-42.747, -58.535], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-			createMarker([-43.229, -49.175], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-			createMarker([-32.045, -17.996], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-			createMarker([-24.107, -22.632], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-			createMarker([-37.684, -30.037], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells maps and crafting supplies'),
-			createMarker([-56.535, -13.931], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies and fish'),
-			createMarker([-22.837, -20.522], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells armour and crafting supplies'),
-			createMarker([-30.676, -2.681], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells maps, crafting supplies, food, and drink'),
-			createMarker([-14.541, -32.080], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells maps and crafting supplies'),
-			createMarker([-7.559, -40.408], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells maps and crafting supplies'),
-			createMarker([-3.401, -34.077], icons.shopkeeper, 'Tailor', '<h1>Tailor</h1>Sells clothes and crafting supplies. Is also a barber'),
-			createMarker([-8.581, -34.321], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Sells maps and crafting supplies'),
-	]);
+		shopkeeper: [{ // Hindarsfjall
+			coords: [[-29.306, 99.492]],
+			label: 'Shopkeeper',
+			popup: 'Sells crafting supplies and fish'
+		}, { // Spikeroog
+			coords: [[31.260, -111.006]],
+			label: 'Shopkeeper',
+			popup: 'Sells crafting supplies and fish'
+		}, { // Ard Skellig
+			coords: [[-64.063, -47.944]],
+			label: 'Shopkeeper',
+			popup: 'Sells maps, crafting supplies, fish and \'Mastercrafted Cavalry Saddle\' (+75)'
+		}, {
+			coords: [[-60.555, -51.416]],
+			label: 'Wandering Merchant',
+			popup: 'Sells maps and crafting supplies'
+		}, {
+			coords: [[-42.747, -58.535]],
+			label: 'Wandering Merchant',
+			popup: 'Sells maps and crafting supplies'
+		}, {
+			coords: [[-43.229, -49.175]],
+			label: 'Wandering Merchant',
+			popup: 'Sells maps and crafting supplies'
+		}, {
+			coords: [[-32.045, -17.996]],
+			label: 'Wandering Merchant',
+			popup: 'Sells maps and crafting supplies'
+		}, {
+			coords: [[-24.107, -22.632]],
+			label: 'Wandering Merchant',
+			popup: 'Sells maps and crafting supplies'
+		}, {
+			coords: [[-37.684, -30.037]],
+			label: 'Shopkeeper',
+			popup: 'Sells maps and crafting supplies'
+		}, {
+			coords: [[-56.535, -13.931]],
+			label: 'Shopkeeper',
+			popup: 'Sells crafting supplies and fish'
+		}, {
+			coords: [[-22.837, -20.522]],
+			label: 'Shopkeeper',
+			popup: 'This merchant appears after liberating the area. Sells armour and crafting supplies'
+		}, {
+			coords: [[-30.676, -2.681]],
+			label: 'Shopkeeper',
+			popup: 'Sells maps, crafting supplies, food, and drink'
+		}, {
+			coords: [[-14.541, -32.080]],
+			label: 'Shopkeeper',
+			popup: 'Sells maps and crafting supplies'
+		}, {
+			coords: [[-7.559, -40.408]],
+			label: 'Shopkeeper',
+			popup: 'Sells maps and crafting supplies'
+		}, {
+			coords: [[-3.401, -34.077]],
+			label: 'Tailor',
+			popup: 'Sells clothes and crafting supplies. Is also a barber'
+		}, {
+			coords: [[-8.581, -34.321]],
+			label: 'Wandering Merchant',
+			popup: 'Sells maps and crafting supplies'
+		}],
 
 	// Sign Post
-	markers.signpost = L.layerGroup([
-		// Faroe
-			createMarker([-77.490, 69.829], icons.signpost, 'Trottheim', '<h1>Trottheim</h1>This village was once famed across all of Skellige for the fact that it was inhabited exclusively by women, all their men having died during one raid or another'),
-			createMarker([-77.206, 49.526], icons.signpost, 'Harviken', '<h1>Harviken</h1>Home seat to Clan Dimun, and the location where Holger Blackhand divvies out the loot after every successful raid'),
-		// Hindarsfjall
-			createMarker([-30.031, 99.272], icons.signpost, 'Larvik', '<h1>Larvik</h1>The largest village on Hindarsfjall and home seat to Donar, head of Clan an Hindar. Its inhabitants are just and god-fearing folk, traditionalists strident in their devotion to Freya'),
-			createMarker([-20.838, 86.177], icons.signpost, 'Freya\'s Garden', '<h1>Freya\'s Garden</h1>Garden dedicated to the goddess Freya. Once beautiful and filled with thousands of fragrant blooms and herbs, today it lies abandoned and untended'),
-			createMarker([-25.463, 81.563], icons.signpost, 'Lofoten', '<h1>Lofoten</h1>Once a rich and vibrant village, today Lofoten is a ravaged and crumbling ruin'),
-			createMarker([-29.764, 82.375], icons.signpost, 'Lofoten Cemetery', '<h1>Lofoten Cemetery</h1>The inhabitants of Lofoten often visit this small cemetery to care for the graves of their loved ones and ask Freya for blessings in the afterlife'),
-			createMarker([-33.505, 85.144], icons.signpost, 'Isolated Hut', '<h1>Isolated Hut</h1>They say this was once home to a herbalist who came to the isles from the continent. Unable to find a place in any of the nearby villages, she settled in this seaside hut, where she recieved the occasional visitor in need of magic creams of bandages'),
-			createMarker([-36.668, 91.604], icons.signpost, 'Lurthen', '<h1>Lurthen</h1>Lurthen\'s most famous inhabitant was a certain Peter Pijus, known for the fact that he was able to drink an entire barrel of mead in one go and remain standing'),
-		// An Skellig
-			createMarker([52.882, 46.230], icons.signpost, 'Trail to Yngvar\'s Fang', '<h1>Trail to Yngvar\'s Fang</h1>This is the start of the mountain trail leading to Yngvar\'s Fang, the pride and glory of An Skellig'),
-			createMarker([54.623, 35.376], icons.signpost, 'Yngvar\'s Fang', '<h1>Yngvar\'s Fang</h1>This mountain peak was named after the mythical bear which, according to legend, was defeated by Tyr, the heroic founder of Clan Tuirsearch'),
-			createMarker([50.092, 38.364], icons.signpost, 'Urialla Harbor', '<h1>Urialla Harbor</h1>On account of their mastery of their craft and painstaking attention to detail, the shipwrights working in this harbor are considered the best in the isles'),
-			createMarker([48.444, 27.510], icons.signpost, 'Bay Of Winds', '<h1>Bay Of Winds</h1>Three generations ago this bay was a popular meeting spot for the local youth. Then one night a terrible storm broke out and the sea pounded into the beach, swallowing up several merry-makers and dragging them out to a watery grave'),
-		// Spikeroog
-			createMarker([33.229, -99.470], icons.signpost, 'Hov', '<h1>Hov</h1>Village known throughout all of Skellige for the infamous arena which once hosted fierce fights between the mightiest warriors in the isles'),
-			createMarker([32.380, -113.005], icons.signpost, 'Svorlag', '<h1>Svorlag</h1>The village was founded by the mythical Sove, who killed a terrifying and bloodthirsty chimera on this spot'),
-			createMarker([22.289, -121.509], icons.signpost, 'Old Watchtower', '<h1>Old Watchtower</h1>The ruins of an old watchtower in which, according to legend, a crazed Koviri princess once locked herself up, convinced only a man able to free her from this tower would be fit to be her husband. No one even tried, however, the princess died of old age and the tower fell into disrepair with the passage of time'),
-		// Eastern Islands
-			createMarker([-16.046, -139.482], icons.signpost, 'The Pali Gap Coast', '<h1>The Pali Gap Coast</h1>Elders say an isolated cave on this coast was once used as a retreat by the world\'s most famous bard (before the rise of Dandelion, that is): the great Xirdneh of Zanguebar, renowned from Nazair to the Dragon Mountains for his ferocious lute-strumming'),
-			createMarker([-8.538, -94.922], icons.signpost, 'Kaer Almhult', '<h1>Kaer Almhult</h1>Built centuries ago to serve as the home keep for the kings of Skellige. In practice, however, each ruler preferred to keep to his clan\'s seat, and Kaer Almhult was left unused. Eventually the decision was made to turn it into a prison, and today the fortress is a crumbling ruin'),
-		// Undvik
-			createMarker([-52.456, -110.391], icons.signpost, 'Marlin Coast', '<h1>Marlin Coast</h1>Until quite recently this beach was frequented by fishermen come to fish marlins out of the nearby waters'),
-			createMarker([-58.984, -98.899], icons.signpost, 'Gull Point', '<h1>Gull Point</h1>Sea fowl come from miles around to congregate on this scrap of barren land, mate and lay eggs'),
-			createMarker([-56.377, -113.533], icons.signpost, 'Dorve Ruins', '<h1>Dorve Ruins</h1>Ruins of a village destroyed by the Ice Giant'),
-			createMarker([-61.365, -121.553], icons.signpost, 'Clan Tordarroch Forge', '<h1>Clan Tordarroch Forge</h1>A famous forge where the best tools and weapons in all of Skellige were once made. When the Ice Giant took over the isle, he turned it into his larder'),
-			createMarker([-58.367, -127.529], icons.signpost, 'Urskar', '<h1>Urskar</h1>The villagers here were famous for their love of pickled herring. They ate it for breakfast, dinner, and supper, and even made jams and compotes out of it'),
-			createMarker([-54.801, -135.176], icons.signpost, 'Abandoned Village', '<h1>Abandoned Village</h1>This village\'s residents were forced to abandon it in a hurry when the Ice Giant unexpectedly awoke and decided to make known his wrath'),
-			createMarker([-43.133, -139.219], icons.signpost, 'Tor Gvalch\'ca', '<h1>Tor Gvalch\'ca</h1>An ancient tower which was erected in the days when elves were the unchallenged masters of these lands'),
-		// Ard Skellig
-			createMarker([-70.707, -6.064], icons.signpost, 'Elverum Lighthouse', '<h1>Elverum Lighthouse</h1>The former keeper of this lighthouse was a confirmed eccentric. In addition to caring for the lighthouse, he also wrote poetry and wove carpets, was known to strip naked and run laps around the lighthouse at noon while shouting "sound mind in a sound body" and for breakfast would eat nothing but fish tails'),
-			createMarker([-58.939, -3.252], icons.signpost, 'Ruined Inn', '<h1>Ruined Inn</h1>Ruined and burned-down tavern which once treated locals and travelers to the best roast lamb around'),
-			createMarker([-55.004, -15.029], icons.signpost, 'Fyresdal', '<h1>Fyresdal</h1>Those living here are tough on the outside, but soft and tender within'),
-			createMarker([-63.085, -38.496], icons.signpost, 'Kaer Muire', '<h1>Kaer Muire</h1>This fortress has served as Clan Drummond\'s home base for centuries. the days when it was new and in full repair are a distant memory now'),
-			createMarker([-64.539, -47.329], icons.signpost, 'Holmstein\'s Port', '<h1>Holmstein\'s Port</h1>Piers and docks for the village of Holmstein - Clan Drummond\'s chief port'),
-			createMarker([-54.098, -60.754], icons.signpost, 'Wild Shore', '<h1>Wild Shore</h1>A wild and untamed™ part of the isle\'s coastline. A favourite spot for bandits and lovers'),
-			createMarker([-50.958, -42.935], icons.signpost, 'Fornhala', '<h1>Fornhala</h1>Mysterious abandoned village'),
-			createMarker([-54.763, 12.964], icons.signpost, 'Distillery', '<h1>Distillery</h1>A shroud of secrecy envelops this place. All that is known is that it produces the finest hooch in all of skellige'),
-			createMarker([-56.837, 23.071], icons.signpost, 'Grotto', '<h1>Grotto</h1>An isolated-off locale that can only be reached by boat'),
-			createMarker([-47.145, -6.812], icons.signpost, 'Palisade', '<h1>Palisade</h1>The remnants of the palisade that once marked the border between the territories of Clan Drummond and Clan an Craite'),
-			createMarker([-43.165, -63.677], icons.signpost, 'Arinbjorn', '<h1>Arinbjorn</h1>A village whose calm is only occasionally disturbed by someone slapping another senseless or one comrade breaking a bottle of mead over his mate\'s head'),
-			createMarker([-40.212, -47.900], icons.signpost, 'Sund', '<h1>Sund</h1>Small village whose inhabitant are for the most part shepherds'),
-			createMarker([-36.351, -31.311], icons.signpost, 'Fayrlund', '<h1>Fayrlund</h1>This small village has gained great renown as home to the best hunters in Skellige'),
-			createMarker([-41.311, -17.886], icons.signpost, 'Boxholm', '<h1>Boxholm</h1>Boxholm was once a thriving village serving the nearby fortress, Kaer Nyssen. Today nothing remains of this past glory but a pile of stones, some debris, and fading memories'),
-			createMarker([-29.306, -25.928], icons.signpost, 'Rannvaig', '<h1>Rannvaig</h1>Fifteen years ago, one of the fishermen of Rannvaig bagged an enormous halibut, and from that moment on all the other villagers have devoted their lives to beating his record'),
-			createMarker([-30.827, -4.219], icons.signpost, 'Blandare', '<h1>Blandare</h1>Unusually for a Skellige village, Blandare is located inland, far from any shore. Its inhabitants scratch out a living through mining and shepherding'),
-			createMarker([-32.064, 14.458], icons.signpost, 'Druids\' Camp', '<h1>Druids\' Camp</h1>Camp pitched by druids investigating the magic cataclysm which devastated the nearby woods'),
-			createMarker([-30.940, 25.356], icons.signpost, 'Redgill', '<h1>Redgill</h1>This village\'s inhabitants fled in a panic when a mysterious magic cataclysm struck the surrounding area'),
-			createMarker([-25.642, 7.031], icons.signpost, 'Abandoned Sawmill', '<h1>Abandoned Sawmill</h1>Though located depp in the forest, an ideal place for lumber harvesting, the sawmill now lies abandoned and unused'),
-			createMarker([-22.614, 12.986], icons.signpost, 'Gedyneith', '<h1>Gedyneith</h1>An oak which is sacred to all Skelligers, as it is worshiped both by druids and Freya\'s disciples. The Isle\'s most important ceremonies are held here, including weddings and royal coronations'),
-			createMarker([-22.533, 17.996], icons.signpost, 'Gedyneith', '<h1>Gedyneith</h1>An oak which is sacred to all Skelligers, as it is worshiped both by druids and Freya\'s disciples. The Isle\'s most important ceremonies are held here, including weddings and royal coronations'),
-			createMarker([-13.475, 24.390], icons.signpost, 'Whale Graveyard', '<h1>Whale Graveyard</h1>The isle\'s inhabitants come here and gather bones which they use to build their huts'),
-			createMarker([-21.002, -30.059], icons.signpost, 'Crossroads', '<h1>Crossroads</h1>Fork in the road leading to Kaer Trolde'),
-			createMarker([-16.341, -9.404], icons.signpost, 'Miners\' Camp', '<h1>Miners\' Camp</h1>Small camp which local miners use as a base during their gold prospecting expeditions into the mountains to the north'),
-			createMarker([-14.520, -70.928], icons.signpost, 'Eldberg Lighthouse', '<h1>Eldberg Lighthouse</h1>Lighthouse build on orders of Jarl Skjordal in order to light the sea and route to Arinbjorn'),
-			createMarker([-12.512, 1.626], icons.signpost, 'Kaer Gelen', '<h1>Kaer Gelen</h1>This old fort\'s ruins attract the sort whom one would not want to run into in a dark alley'),
-			createMarker([-7.067, -37.617], icons.signpost, 'Kaer Trolde Harbor', '<h1>Kaer Trolde Harbor</h1>One of the busiest ports in Skellige. Goods from every corner of the world are brought here to be sold and traded'),
-			createMarker([2.636, -38.650], icons.signpost, 'Bridge to Kaer Trolde', '<h1>Bridge to Kaer Trolde</h1>This stone bridge was, according to legend, carved single-handedly by Grymmdjarr, the heroic founder of Clan an Craite'),
-			createMarker([-8.494, -18.171], icons.signpost, 'Rogne', '<h1>Rogne</h1>This mountain settlement is home to tough folk of indomitable spirit'),
-			createMarker([-1.384, -1.956], icons.signpost, 'Yustianna\'s Grotto', '<h1>Yustianna\'s Grotto</h1>Yustianna was a pirate born of a Skelliger from Clan an Craite and a captive woman taken during a raid. In her time she was feared on the Continent from Ofir to Zanguebar. Known for her skill as a navigator and unmatched master of various weapons, she quickly became the terror of the Great Sea, and when she returned to Skellige, they say this cave is where she hid her loot'),
-			createMarker([2.724, 15.029], icons.signpost, 'Giants\' Toes', '<h1>Giants\' Toes</h1>In truth simply a normal rock formation shaped by centuries of wind and water, islanders believe Uroboros punished giants who opposed his will by turning them into these stones'),
-			createMarker([9.947, -22.039], icons.signpost, 'Ancient Crypt', '<h1>Ancient Crypt</h1>Though Skelligers are famed for bravery bordering on madness, there are certain places which even they keep their distance from. This is one of them'),
-	]);
+		signpost: [{ // Faroe
+			coords: [[-77.490, 69.829]],
+			label: 'Trottheim',
+			popup: 'This village was once famed across all of Skellige for the fact that it was inhabited exclusively by women, all their men having died during one raid or another'
+		}, {
+			coords: [[-77.206, 49.526]],
+			label: 'Harviken',
+			popup: 'Home seat to Clan Dimun, and the location where Holger Blackhand divvies out the loot after every successful raid'
+		}, { // Hindarsfjall
+			coords: [[-30.031, 99.272]],
+			label: 'Larvik',
+			popup: 'The largest village on Hindarsfjall and home seat to Donar, head of Clan an Hindar. Its inhabitants are just and god-fearing folk, traditionalists strident in their devotion to Freya'
+		}, {
+			coords: [[-20.838, 86.177]],
+			label: 'Freya\'s Garden',
+			popup: 'Garden dedicated to the goddess Freya. Once beautiful and filled with thousands of fragrant blooms and herbs, today it lies abandoned and untended'
+		}, {
+			coords: [[-25.463, 81.563]],
+			label: 'Lofoten',
+			popup: 'Once a rich and vibrant village, today Lofoten is a ravaged and crumbling ruin'
+		}, {
+			coords: [[-29.764, 82.375]],
+			label: 'Lofoten Cemetery',
+			popup: 'The inhabitants of Lofoten often visit this small cemetery to care for the graves of their loved ones and ask Freya for blessings in the afterlife'
+		}, {
+			coords: [[-33.505, 85.144]],
+			label: 'Isolated Hut',
+			popup: 'They say this was once home to a herbalist who came to the isles from the continent. Unable to find a place in any of the nearby villages, she settled in this seaside hut, where she recieved the occasional visitor in need of magic creams of bandages'
+		}, {
+			coords: [[-36.668, 91.604]],
+			label: 'Lurthen',
+			popup: 'Lurthen\'s most famous inhabitant was a certain Peter Pijus, known for the fact that he was able to drink an entire barrel of mead in one go and remain standing'
+		}, { // An Skellig
+			coords: [[52.882, 46.230]],
+			label: 'Trail to Yngvar\'s Fang',
+			popup: 'This is the start of the mountain trail leading to Yngvar\'s Fang, the pride and glory of An Skellig'
+		}, {
+			coords: [[54.623, 35.376]],
+			label: 'Yngvar\'s Fang',
+			popup: 'This mountain peak was named after the mythical bear which, according to legend, was defeated by Tyr, the heroic founder of Clan Tuirsearch'
+		}, {
+			coords: [[50.092, 38.364]],
+			label: 'Urialla Harbor',
+			popup: 'On account of their mastery of their craft and painstaking attention to detail, the shipwrights working in this harbor are considered the best in the isles'
+		}, {
+			coords: [[48.444, 27.510]],
+			label: 'Bay Of Winds',
+			popup: 'Three generations ago this bay was a popular meeting spot for the local youth. Then one night a terrible storm broke out and the sea pounded into the beach, swallowing up several merry-makers and dragging them out to a watery grave'
+		}, { // Spikeroog
+			coords: [[33.229, -99.470]],
+			label: 'Hov',
+			popup: 'Village known throughout all of Skellige for the infamous arena which once hosted fierce fights between the mightiest warriors in the isles'
+		}, {
+			coords: [[32.380, -113.005]],
+			label: 'Svorlag',
+			popup: 'The village was founded by the mythical Sove, who killed a terrifying and bloodthirsty chimera on this spot'
+		}, {
+			coords: [[22.289, -121.509]],
+			label: 'Old Watchtower',
+			popup: 'The ruins of an old watchtower in which, according to legend, a crazed Koviri princess once locked herself up, convinced only a man able to free her from this tower would be fit to be her husband. No one even tried, however, the princess died of old age and the tower fell into disrepair with the passage of time'
+		}, { // Eastern Islands
+			coords: [[-16.046, -139.482]],
+			label: 'The Pali Gap Coast',
+			popup: 'Elders say an isolated cave on this coast was once used as a retreat by the world\'s most famous bard (before the rise of Dandelion, that is): the great Xirdneh of Zanguebar, renowned from Nazair to the Dragon Mountains for his ferocious lute-strumming'
+		}, {
+			coords: [[-8.538, -94.922]],
+			label: 'Kaer Almhult',
+			popup: 'Built centuries ago to serve as the home keep for the kings of Skellige. In practice, however, each ruler preferred to keep to his clan\'s seat, and Kaer Almhult was left unused. Eventually the decision was made to turn it into a prison, and today the fortress is a crumbling ruin'
+		}, { // Undvik
+			coords: [[-52.456, -110.391]],
+			label: 'Marlin Coast',
+			popup: 'Until quite recently this beach was frequented by fishermen come to fish marlins out of the nearby waters'
+		}, {
+			coords: [[-58.984, -98.899]],
+			label: 'Gull Point',
+			popup: 'Sea fowl come from miles around to congregate on this scrap of barren land, mate and lay eggs'
+		}, {
+			coords: [[-56.377, -113.533]],
+			label: 'Dorve Ruins',
+			popup: 'Ruins of a village destroyed by the Ice Giant'
+		}, {
+			coords: [[-61.365, -121.553]],
+			label: 'Clan Tordarroch Forge',
+			popup: 'A famous forge where the best tools and weapons in all of Skellige were once made. When the Ice Giant took over the isle, he turned it into his larder'
+		}, {
+			coords: [[-58.367, -127.529]],
+			label: 'Urskar',
+			popup: 'The villagers here were famous for their love of pickled herring. They ate it for breakfast, dinner, and supper, and even made jams and compotes out of it'
+		}, {
+			coords: [[-54.801, -135.176]],
+			label: 'Abandoned Village',
+			popup: 'This village\'s residents were forced to abandon it in a hurry when the Ice Giant unexpectedly awoke and decided to make known his wrath'
+		}, {
+			coords: [[-43.133, -139.219]],
+			label: 'Tor Gvalch\'ca',
+			popup: 'An ancient tower which was erected in the days when elves were the unchallenged masters of these lands'
+		}, { // Ard Skellig
+			coords: [[-70.707, -6.064]],
+			label: 'Elverum Lighthouse',
+			popup: 'The former keeper of this lighthouse was a confirmed eccentric. In addition to caring for the lighthouse, he also wrote poetry and wove carpets, was known to strip naked and run laps around the lighthouse at noon while shouting "sound mind in a sound body" and for breakfast would eat nothing but fish tails'
+		}, {
+			coords: [[-58.939, -3.252]],
+			label: 'Ruined Inn',
+			popup: 'Ruined and burned-down tavern which once treated locals and travelers to the best roast lamb around'
+		}, {
+			coords: [[-55.004, -15.029]],
+			label: 'Fyresdal',
+			popup: 'Those living here are tough on the outside, but soft and tender within'
+		}, {
+			coords: [[-63.085, -38.496]],
+			label: 'Kaer Muire',
+			popup: 'This fortress has served as Clan Drummond\'s home base for centuries. the days when it was new and in full repair are a distant memory now'
+		}, {
+			coords: [[-64.539, -47.329]],
+			label: 'Holmstein\'s Port',
+			popup: 'Piers and docks for the village of Holmstein - Clan Drummond\'s chief port'
+		}, {
+			coords: [[-54.098, -60.754]],
+			label: 'Wild Shore',
+			popup: 'A wild and untamed™ part of the isle\'s coastline. A favourite spot for bandits and lovers'
+		}, {
+			coords: [[-50.958, -42.935]],
+			label: 'Fornhala',
+			popup: 'Mysterious abandoned village'
+		}, {
+			coords: [[-54.763, 12.964]],
+			label: 'Distillery',
+			popup: 'A shroud of secrecy envelops this place. All that is known is that it produces the finest hooch in all of skellige'
+		}, {
+			coords: [[-56.837, 23.071]],
+			label: 'Grotto',
+			popup: 'An isolated-off locale that can only be reached by boat'
+		}, {
+			coords: [[-47.145, -6.812]],
+			label: 'Palisade',
+			popup: 'The remnants of the palisade that once marked the border between the territories of Clan Drummond and Clan an Craite'
+		}, {
+			coords: [[-43.165, -63.677]],
+			label: 'Arinbjorn',
+			popup: 'A village whose calm is only occasionally disturbed by someone slapping another senseless or one comrade breaking a bottle of mead over his mate\'s head'
+		}, {
+			coords: [[-40.212, -47.900]],
+			label: 'Sund',
+			popup: 'Small village whose inhabitant are for the most part shepherds'
+		}, {
+			coords: [[-36.351, -31.311]],
+			label: 'Fayrlund',
+			popup: 'This small village has gained great renown as home to the best hunters in Skellige'
+		}, {
+			coords: [[-41.311, -17.886]],
+			label: 'Boxholm',
+			popup: 'Boxholm was once a thriving village serving the nearby fortress, Kaer Nyssen. Today nothing remains of this past glory but a pile of stones, some debris, and fading memories'
+		}, {
+			coords: [[-29.306, -25.928]],
+			label: 'Rannvaig',
+			popup: 'Fifteen years ago, one of the fishermen of Rannvaig bagged an enormous halibut, and from that moment on all the other villagers have devoted their lives to beating his record'
+		}, {
+			coords: [[-30.827, -4.219]],
+			label: 'Blandare',
+			popup: 'Unusually for a Skellige village, Blandare is located inland, far from any shore. Its inhabitants scratch out a living through mining and shepherding'
+		}, {
+			coords: [[-32.064, 14.458]],
+			label: 'Druids\' Camp',
+			popup: 'Camp pitched by druids investigating the magic cataclysm which devastated the nearby woods'
+		}, {
+			coords: [[-30.940, 25.356]],
+			label: 'Redgill',
+			popup: 'This village\'s inhabitants fled in a panic when a mysterious magic cataclysm struck the surrounding area'
+		}, {
+			coords: [[-25.642, 7.031]],
+			label: 'Abandoned Sawmill',
+			popup: 'Though located depp in the forest, an ideal place for lumber harvesting, the sawmill now lies abandoned and unused'
+		}, {
+			coords: [[-22.614, 12.986]],
+			label: 'Gedyneith',
+			popup: 'An oak which is sacred to all Skelligers, as it is worshiped both by druids and Freya\'s disciples. The Isle\'s most important ceremonies are held here, including weddings and royal coronations'
+		}, {
+			coords: [[-22.533, 17.996]],
+			label: 'Gedyneith',
+			popup: 'An oak which is sacred to all Skelligers, as it is worshiped both by druids and Freya\'s disciples. The Isle\'s most important ceremonies are held here, including weddings and royal coronations'
+		}, {
+			coords: [[-13.475, 24.390]],
+			label: 'Whale Graveyard',
+			popup: 'The isle\'s inhabitants come here and gather bones which they use to build their huts'
+		}, {
+			coords: [[-21.002, -30.059]],
+			label: 'Crossroads',
+			popup: 'Fork in the road leading to Kaer Trolde'
+		}, {
+			coords: [[-16.341, -9.404]],
+			label: 'Miners\' Camp',
+			popup: 'Small camp which local miners use as a base during their gold prospecting expeditions into the mountains to the north'
+		}, {
+			coords: [[-14.520, -70.928]],
+			label: 'Eldberg Lighthouse',
+			popup: 'Lighthouse build on orders of Jarl Skjordal in order to light the sea and route to Arinbjorn'
+		}, {
+			coords: [[-12.512, 1.626]],
+			label: 'Kaer Gelen',
+			popup: 'This old fort\'s ruins attract the sort whom one would not want to run into in a dark alley'
+		}, {
+			coords: [[-7.067, -37.617]],
+			label: 'Kaer Trolde Harbor',
+			popup: 'One of the busiest ports in Skellige. Goods from every corner of the world are brought here to be sold and traded'
+		}, {
+			coords: [[2.636, -38.650]],
+			label: 'Bridge to Kaer Trolde',
+			popup: 'This stone bridge was, according to legend, carved single-handedly by Grymmdjarr, the heroic founder of Clan an Craite'
+		}, {
+			coords: [[-8.494, -18.171]],
+			label: 'Rogne',
+			popup: 'This mountain settlement is home to tough folk of indomitable spirit'
+		}, {
+			coords: [[-1.384, -1.956]],
+			label: 'Yustianna\'s Grotto',
+			popup: 'Yustianna was a pirate born of a Skelliger from Clan an Craite and a captive woman taken during a raid. In her time she was feared on the Continent from Ofir to Zanguebar. Known for her skill as a navigator and unmatched master of various weapons, she quickly became the terror of the Great Sea, and when she returned to Skellige, they say this cave is where she hid her loot'
+		}, {
+			coords: [[2.724, 15.029]],
+			label: 'Giants\' Toes',
+			popup: 'In truth simply a normal rock formation shaped by centuries of wind and water, islanders believe Uroboros punished giants who opposed his will by turning them into these stones'
+		}, {
+			coords: [[9.947, -22.039]],
+			label: 'Ancient Crypt',
+			popup: 'Though Skelligers are famed for bravery bordering on madness, there are certain places which even they keep their distance from. This is one of them'
+		}],
 
 	// Smugglers' Cache
-	var smugglersGeneric = genericMarkers([
-		[-27.722, -50.098],
-		[-23.080, -57.832],
-		[-18.146, -48.955],
-		[-10.185, -52.163],
-		[-3.996, -61.304],
-		[4.215, -57.173],
-		[12.340, -56.865],
-		[7.885, -68.423],
-		[0.527, -91.846],
-		[-18.355, -82.266],
-		[-24.327, -80.771],
-		[-21.576, -105.469],
-		[-16.594, -121.992],
-		[1.099, -119.971],
-		[12.426, -101.250],
-		[21.943, -72.949],
-		[36.809, -62.007],
-		[36.809, -30.366],
-		[29.075, -33.706],
-		[16.720, -35.288],
-		[17.811, -24.829],
-		[24.767, -10.942],
-		[15.538, -3.560],
-		[32.027, 8.833],
-		[37.788, 47.813],
-		[36.527, 43.154],
-		[37.719, 33.926],
-		[21.617, 48.691],
-		[25.919, 84.463],
-		[-7.362, 28.389],
-		[2.328, 27.686],
-		[-6.446, 38.848],
-		[2.153, 37.793],
-		[-10.617, 47.417],
-		[-11.092, 59.985],
-		[-11.092, 70.884],
-		[-26.195, 60.029],
-		[-56.705, 79.805],
-		[-60.759, 40.430],
-		[-62.042, 25.269],
-		[-66.496, 3.120],
-		[-68.544, 8.657],
-		[-77.332, 13.623],
-		[-76.321, -22.148],
-		[-77.351, -47.065],
-		[-78.853, -121.729],
-		[-74.068, -79.365],
-		[-70.613, -55.986],
-		[-66.896, -83.145],
-		[-57.374, -78.311],
-		[-41.079, -76.421],
-		[-41.673, -92.505],
-		[-37.125, -97.383],
-		[-36.510, -82.046],
-		[61.186, -90.264],
-		[53.697, -55.371],
-		[52.107, -22.500],
-		[56.023, -8.877],
-	], icons.smugglers, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
+		smugglers: [{
+			coords: [
+				[-27.722, -50.098],
+				[-23.080, -57.832],
+				[-18.146, -48.955],
+				[-10.185, -52.163],
+				[-3.996, -61.304],
+				[4.215, -57.173],
+				[12.340, -56.865],
+				[7.885, -68.423],
+				[0.527, -91.846],
+				[-18.355, -82.266],
+				[-24.327, -80.771],
+				[-21.576, -105.469],
+				[-16.594, -121.992],
+				[1.099, -119.971],
+				[12.426, -101.250],
+				[21.943, -72.949],
+				[36.809, -62.007],
+				[36.809, -30.366],
+				[29.075, -33.706],
+				[16.720, -35.288],
+				[17.811, -24.829],
+				[24.767, -10.942],
+				[15.538, -3.560],
+				[32.027, 8.833],
+				[37.788, 47.813],
+				[36.527, 43.154],
+				[37.719, 33.926],
+				[21.617, 48.691],
+				[25.919, 84.463],
+				[-7.362, 28.389],
+				[2.328, 27.686],
+				[-6.446, 38.848],
+				[2.153, 37.793],
+				[-10.617, 47.417],
+				[-11.092, 59.985],
+				[-11.092, 70.884],
+				[-26.195, 60.029],
+				[-56.705, 79.805],
+				[-60.759, 40.430],
+				[-62.042, 25.269],
+				[-66.496, 3.120],
+				[-68.544, 8.657],
+				[-77.332, 13.623],
+				[-76.321, -22.148],
+				[-77.351, -47.065],
+				[-78.853, -121.729],
+				[-74.068, -79.365],
+				[-70.613, -55.986],
+				[-66.896, -83.145],
+				[-57.374, -78.311],
+				[-41.079, -76.421],
+				[-41.673, -92.505],
+				[-37.125, -97.383],
+				[-36.510, -82.046],
+				[61.186, -90.264],
+				[53.697, -55.371],
+				[52.107, -22.500],
+				[56.023, -8.877],
+			],
+			label: 'Smuggler\'s Cache',
+			popup: 'Smuggled goods have been hidden here'
+		}],
 
-	markers.smugglers = L.layerGroup($.merge(smugglersGeneric, [
-		// No custom markers needed
-	]));
 
 	// Spoils of War
-	markers.spoils = L.layerGroup(genericMarkers([
-		[29.650, -63.896],
-		[21.412, -47.285],
-		[-50.709, 43.550],
-		[-69.396, 25.356],
-		[-77.466, -63.193],
-		[-16.426, -144.009],
-		[-20.879, -158.467],
-		[57.891, -28.564],
-	], icons.spoils, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'));
+		spoils: [{
+			coords: [
+				[29.650, -63.896],
+				[21.412, -47.285],
+				[-50.709, 43.550],
+				[-69.396, 25.356],
+				[-77.466, -63.193],
+				[-16.426, -144.009],
+				[-20.879, -158.467],
+				[57.891, -28.564],
+			],
+			label: 'Spoils of War',
+			popup: 'Search here for loot left behind after a battle or skirmish'
+		}],
+	});
 
 	window.allLayers = [
 		markers.abandoned,

--- a/files/js/mapdata-skellige.js
+++ b/files/js/mapdata-skellige.js
@@ -1,10 +1,11 @@
-$(function()
-{
-	map_path   = 'skellige';
-	map_sWest  = L.latLng(-85.05, -180);
-	map_nEast  = L.latLng(79.30, 135);
-	map_center = [-35, -10];
-	map_mZoom  = 6;
+$(function() {
+	window.map_path   = 'skellige';
+	window.map_sWest  = L.latLng(-85.05, -180);
+	window.map_nEast  = L.latLng(79.30, 135);
+	window.map_center = [-35, -10];
+	window.map_mZoom  = 6;
+
+	window.markers = {};
 
 	// Abandoned Site
 		var abandonedIcon = L.icon({
@@ -12,7 +13,7 @@ $(function()
 			iconSize : [30, 30]
 		});
 
-		abandonedMarkers = L.layerGroup(genericMarkers([
+		window.markers['abandoned'] = L.layerGroup(genericMarkers([
 			// Hindarsfjall
 				[-35.996, 92.439],
 				[-32.916, 85.562],
@@ -27,7 +28,7 @@ $(function()
 			iconSize : [20, 28]
 		});
 
-		alchemyMarkers = L.layerGroup([
+		window.markers['alchemy'] = L.layerGroup([
 			L.marker([-20.468, 93.318], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies').bindPopup('<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
 			L.marker([-28.208, -26.147], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies').bindPopup('<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
 			L.marker([-19.705, 17.314], setMarker(alchemyIcon)).bindLabel('Gremist').bindPopup('<h1>Gremist</h1>\'Practicum in Advanced Alchemy\' (lvl 24) Quest'),
@@ -39,7 +40,7 @@ $(function()
 			iconSize : [24, 34]
 		});
 
-		armourerMarkers = L.layerGroup([
+		window.markers['armourer'] = L.layerGroup([
 			// Hindarsfjall
 				L.marker([-29.037, 98.569], setMarker(armourerIcon)).bindLabel('Amateur Armorer').bindPopup('<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
 			// An Skellig
@@ -55,7 +56,7 @@ $(function()
 			iconSize : [30, 27]
 		});
 
-		armourerstableMarkers = L.layerGroup(genericMarkers([
+		window.markers['armourerstable'] = L.layerGroup(genericMarkers([
 			// Hindarsfjall
 				[-28.159, 101.851],
 				[-28.825, 98.062],
@@ -76,7 +77,7 @@ $(function()
 			iconSize : [29, 30]
 		});
 
-		banditcampMarkers = L.layerGroup(genericMarkers([
+		window.markers['banditcamp'] = L.layerGroup(genericMarkers([
 			// Spikeroog
 				[21.861, -121.047],
 			// Ard Skellig
@@ -94,7 +95,7 @@ $(function()
 			iconSize : [30, 30]
 		});
 
-		barberMarkers = L.layerGroup(genericMarkers([
+		window.markers['barber'] = L.layerGroup(genericMarkers([
 			// Spikeroog
 				[31.072, -111.973],
 				[-3.601, -34.277],
@@ -106,7 +107,7 @@ $(function()
 			iconSize : [27, 30]
 		});
 
-		blacksmithMarkers = L.layerGroup([
+		window.markers['blacksmith'] = L.layerGroup([
 			// Faroe
 				L.marker([-77.390, 50.142], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
 			// Hindarsfjall
@@ -129,7 +130,7 @@ $(function()
 			iconSize : [28, 26]
 		});
 
-		brothelMarkers = L.layerGroup([]);
+		window.markers['brothel'] = L.layerGroup([]);
 
 	// Entrance
 		var entranceIcon = L.icon({
@@ -138,7 +139,7 @@ $(function()
 		});
 
 		// todo, entrance to what?
-		entranceMarkers = L.layerGroup([
+		window.markers['entrance'] = L.layerGroup([
 			// Faroe
 				L.marker([-78.469, 43.484], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
 				L.marker([-77.250, 44.187], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
@@ -186,7 +187,7 @@ $(function()
 			iconSize : [30, 26]
 		});
 
-		grindstoneMarkers = L.layerGroup(genericMarkers([
+		window.markers['grindstone'] = L.layerGroup(genericMarkers([
 			// Faroe
 				[-77.355, 50.647],
 			// Hindarsfjall
@@ -240,7 +241,7 @@ $(function()
 				[57.845, -1.670],
 		], guardedIcon, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
 
-		guardedMarkers = L.layerGroup($.merge(guardedGeneric, [
+		window.markers['guarded'] = L.layerGroup($.merge(guardedGeneric, [
 			// No custom markers needed
 		]));
 
@@ -250,7 +251,7 @@ $(function()
 			iconSize : [24, 30]
 		});
 
-		gwentMarkers = L.layerGroup([
+		window.markers['gwent'] = L.layerGroup([
 			// Faroe
 				L.marker([-77.455, 49.227], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
 				L.marker([-77.350, 50.242], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
@@ -290,7 +291,7 @@ $(function()
 			iconSize : [27, 30]
 		});
 
-		harborMarkers = L.layerGroup(genericMarkers([
+		window.markers['harbor'] = L.layerGroup(genericMarkers([
 			[-6.075, -40.496],
 			[11.265, -23.005],
 			[-28.498, -28.696],
@@ -322,7 +323,7 @@ $(function()
 				[-6.097, -34.607],
 		], herbalistIcon, 'Herbalist', '<h1>Herbalist</h1>Here you can buy alchemy ingredients');
 
-		herbalistMarkers = L.layerGroup($.merge(herbalistGeneric, [
+		window.markers['herbalist'] = L.layerGroup($.merge(herbalistGeneric, [
 			// No custom markers needed
 		]));
 
@@ -368,7 +369,7 @@ $(function()
 				[50.373, -7.515],
 		], hiddenIcon, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
 
-		hiddenMarkers = L.layerGroup($.merge(hiddenGeneric, [
+		window.markers['hidden'] = L.layerGroup($.merge(hiddenGeneric, [
 			// No custom markers needed
 		]));
 
@@ -378,7 +379,7 @@ $(function()
 			iconSize : [26, 30]
 		});
 
-		innkeepMarkers = L.layerGroup([
+		window.markers['innkeep'] = L.layerGroup([
 			// Faroe
 				L.marker([-77.485, 49.007], setMarker(innkeepIcon)).bindLabel('Harviken Inn').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
 			// Hindarsfjall
@@ -409,7 +410,7 @@ $(function()
 				[-2.416, -21.841],
 		], monsterdenIcon, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby');
 
-		monsterdenMarkers = L.layerGroup($.merge(monsterdenGeneric, [
+		window.markers['monsterden'] = L.layerGroup($.merge(monsterdenGeneric, [
 			// No custom markers needed
 		]));
 
@@ -429,7 +430,7 @@ $(function()
 				[-23.544, -37.551],
 		], monsternestIcon, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
 
-		monsternestMarkers = L.layerGroup($.merge(monsternestGeneric, [
+		window.markers['monsternest'] = L.layerGroup($.merge(monsternestGeneric, [
 			// No custom markers needed
 		]));
 
@@ -439,7 +440,7 @@ $(function()
 			iconSize : [23, 28]
 		});
 
-		noticeMarkers = L.layerGroup(genericMarkers([
+		window.markers['notice'] = L.layerGroup(genericMarkers([
 			// Hindarsfjall
 				[-28.343, 100.239],
 			// Spikeroog
@@ -464,7 +465,7 @@ $(function()
 			[-38.994, -6.372],
 		], pidIcon, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance');
 
-		pidMarkers = L.layerGroup($.merge(pidGeneric, [
+		window.markers['pid'] = L.layerGroup($.merge(pidGeneric, [
 			// No custom markers needed
 		]));
 
@@ -475,7 +476,7 @@ $(function()
 		});
 
 		//todo get all place of power types
-		popMarkers = L.layerGroup([
+		window.markers['pop'] = L.layerGroup([
 			// Faroe
 				L.marker([-76.851, 40.891], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any 	Place of Power, you also receive 1 Ability Point'),
 			// An Skellig
@@ -498,7 +499,7 @@ $(function()
 		});
 
 
-		poiMarkers = L.layerGroup([
+		window.markers['poi'] = L.layerGroup([
 			// Faroe
 				L.marker([-76.985, 57.788], setMarker(poiIcon)).bindLabel('Jutta An Dimun').bindPopup('<h1>Jutta An Dimun</h1>todo'), //double check this
 			// Ard Skellig
@@ -515,7 +516,7 @@ $(function()
 			iconSize : [21, 30]
 		});
 
-		shopkeeperMarkers = L.layerGroup([
+		window.markers['shopkeeper'] = L.layerGroup([
 			// Hindarsfjall
 				L.marker([-29.306, 99.492], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells crafting supplies and fish'),
 			// Spikeroog
@@ -543,7 +544,7 @@ $(function()
 			iconSize : [27, 34]
 		});
 
-		signpostMarkers = L.layerGroup([
+		window.markers['signpost'] = L.layerGroup([
 			// Faroe
 				L.marker([-77.490, 69.829], setMarker(signpostIcon)).bindLabel('Trottheim').bindPopup('<h1>Trottheim</h1>This village was once famed across all of Skellige for the fact that it was inhabited exclusively by women, all their men having died during one raid or another'),
 				L.marker([-77.206, 49.526], setMarker(signpostIcon)).bindLabel('Harviken').bindPopup('<h1>Harviken</h1>Home seat to Clan Dimun, and the location where Holger Blackhand divvies out the loot after every successful raid'),
@@ -676,7 +677,7 @@ $(function()
 			[56.023, -8.877],
 		], smugglersIcon, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
 
-		smugglersMarkers = L.layerGroup($.merge(smugglersGeneric, [
+		window.markers['smugglers'] = L.layerGroup($.merge(smugglersGeneric, [
 			// No custom markers needed
 		]));
 
@@ -686,7 +687,7 @@ $(function()
 			iconSize : [25, 28]
 		});
 
-		spoilsMarkers = L.layerGroup(genericMarkers([
+		window.markers['spoils'] = L.layerGroup(genericMarkers([
 			[29.650, -63.896],
 			[21.412, -47.285],
 			[-50.709, 43.550],
@@ -697,18 +698,32 @@ $(function()
 			[57.891, -28.564],
 		], spoilsIcon, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'));
 
-	allLayers = [abandonedMarkers, alchemyMarkers, armourerMarkers, armourerstableMarkers, banditcampMarkers, barberMarkers, blacksmithMarkers, brothelMarkers, entranceMarkers, grindstoneMarkers, guardedMarkers, gwentMarkers, harborMarkers, herbalistMarkers, hiddenMarkers, innkeepMarkers, monsterdenMarkers, monsternestMarkers, noticeMarkers, pidMarkers, popMarkers, poiMarkers, shopkeeperMarkers, signpostMarkers, smugglersMarkers, spoilsMarkers];
+	window.allLayers = [
+		window.markers['abandoned'],
+		window.markers['alchemy'],
+		window.markers['armourer'],
+		window.markers['armourerstable'],
+		window.markers['banditcamp'],
+		window.markers['barber'],
+		window.markers['blacksmith'],
+		window.markers['brothel'],
+		window.markers['entrance'],
+		window.markers['grindstone'],
+		window.markers['guarded'],
+		window.markers['gwent'],
+		window.markers['harbor'],
+		window.markers['herbalist'],
+		window.markers['hidden'],
+		window.markers['innkeep'],
+		window.markers['monsterden'],
+		window.markers['monsternest'],
+		window.markers['notice'],
+		window.markers['pid'],
+		window.markers['pop'],
+		window.markers['poi'],
+		window.markers['shopkeeper'],
+		window.markers['signpost'],
+		window.markers['smugglers'],
+		window.markers['spoils']
+	];
 });
-
-function genericMarkers(cords, icon, label, popup) {
-	var out = [];
-	$.each(cords, function(key, val)
-	{
-		out.push(L.marker(val, setMarker(icon)).bindLabel(label).bindPopup(popup));
-	});
-	return out;
-}
-
-function setMarker(icon, tooltip) {
-	return {icon : icon, riseOnHover : true};
-}

--- a/files/js/mapdata-velen.js
+++ b/files/js/mapdata-velen.js
@@ -5,813 +5,1872 @@
 	window.map_center = [60, -5];
 	window.map_mZoom  = 6;
 
-	var icons = window.icons;
-	var markers = window.markers;
-
+	processData({
 	// Abandoned Site
-	var abandonedGeneric = genericMarkers([
-		// NW Velen
-			[-53.59, -56.34],
-			[-29.34, -136.23],
-			[-50.25, -140.63],
-			[-58.95, -142.21],
-	], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more');
-
-	markers.abandoned = L.layerGroup($.merge(abandonedGeneric, [
-		// NE Velen
-			createMarker([-17.06, 8.26], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 4<span> Drowners</span>)'),
-			createMarker([13.70, 46.05], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Drowners</span>)'),
-			createMarker([-8.23, 72.16], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Ghouls</span> &amp; lvl 11<span> Alghoul</span>)'),
-		// SW Velen
-			createMarker([-79.70, -112.15], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Bandits</span>)'),
-			createMarker([-78.68, -40.69], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Endregas</span>)'),
-		// SE Velen
-			createMarker([-36.95, 3.08], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 5<span> Bandits</span>)'),
-	]));
+		abandoned: [{
+			coords: [
+				// NW Velen
+				[-53.59, -56.34],
+				[-29.34, -136.23],
+				[-50.25, -140.63],
+				[-58.95, -142.21]
+			],
+			label: 'Abandoned Site',
+			popup: 'A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more'
+		}, { // NE Velen
+			coords: [[-17.06, 8.26]],
+			label: 'Abandoned Site',
+			popup: 'A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 4<span> Drowners</span>)'
+		}, {
+			coords: [[13.70, 46.05]],
+			label: 'Abandoned Site',
+			popup: 'A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Drowners</span>)'
+		}, {
+			coords: [[-8.23, 72.16]],
+			label: 'Abandoned Site',
+			popup: 'A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Ghouls</span> &amp; lvl 11<span> Alghoul</span>)'
+		}, { // SW Velen
+			coords: [[-79.70, -112.15]],
+			label: 'Abandoned Site',
+			popup: 'A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Bandits</span>)'
+		}, {
+			coords: [[-78.68, -40.69]],
+			label: 'Abandoned Site',
+			popup: 'A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Endregas</span>)'
+		}, { // SE Velen
+			coords: [[-36.95, 3.08]],
+			label: 'Abandoned Site',
+			popup: 'A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 5<span> Bandits</span>)'
+		}],
 
 	// Alchemy Supplies
-	markers.alchemy = L.layerGroup([
-		// Novigrad
-			createMarker([77.71, -15.91], icons.alchemy, 'Alchemy Supplies*', '<h1>Alchemy Supplies*</h1>Here you can buy alchemy ingredients, also pays well trophies'),
-			createMarker([79.75, -49.83], icons.alchemy, 'Alchemy Supplies', '<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
-		// NW Velen
-			createMarker([-18.52, -110.21], icons.alchemy, 'Alchemy Supplies', '<h1>Pellar</h1>Here you can buy alchemy ingredients'),
-	]);
+		alchemy: [{ //Novigrad
+			coords: [[77.71, -15.91]],
+			label: 'Alchemy Supplies*',
+			popup: 'Here you can buy alchemy ingredients, also pays well trophies'
+		}, {
+			coords: [[79.75, -49.83]],
+			label: 'Alchemy Supplies',
+			popup: 'Here you can buy alchemy ingredients'
+		}, { // NW Velen
+			coords: [[-18.52, -110.21]],
+			label: 'Alchemy Supplies',
+			popupTitle: 'Pellar',
+			popup: 'Here you can buy alchemy ingredients'
+		}],
 
 	// Armourer
-
-
-	markers.armourer = L.layerGroup([
-		// Novigrad
-			createMarker([74.23, -38.23], icons.armourer, 'Journeyman Armorer', '<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// Oxenfurt
-			createMarker([38.82, 54.01], icons.armourer, 'Journeyman Armorer', '<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// NE Velen
-			createMarker([2.18, -12.92], icons.armourer, 'Amateur Armorer', '<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// NW Velen
-			createMarker([-31.25, -71.02], icons.armourer, 'Journeyman Armorer', '<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			createMarker([-54.06, -122.97], icons.armourer, 'Amateur Armorer', '<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			createMarker([-30.87, -71.63], icons.armourer, 'Master Armorer*', '<h1>Master Armorer* (Yoana)</h1>Is available after the \'Master Armorers\' (lvl 26) quest. Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-	]);
+		armourer: [{ // Novigrad
+			coords: [[74.23, -38.23]],
+			label: 'Journeyman Armorer',
+			popup: 'Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // Oxenfurt
+			coords: [[38.82, 54.01]],
+			label: 'Journeyman Armorer',
+			popup: 'Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // NE Velen
+			coords: [[2.18, -12.92]],
+			label: 'Amateur Armorer',
+			popup: 'Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // NW Velen
+			coords: [[-31.25, -71.02]],
+			label: 'Journeyman Armorer',
+			popup: 'Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, {
+			coords: [[-54.06, -122.97]],
+			label: 'Amateur Armorer',
+			popup: 'Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, {
+			coords: [[-30.87, -71.63]],
+			label: 'Master Armorer*',
+			popupTitle: 'Master Armorer* (Yoana)',
+			popup: 'Is available after the "Master Armorers" (lvl 26) quest. Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}],
 
 	// Armourer's Table
-	markers.armourerstable = L.layerGroup(genericMarkers([
-		// Novigrad
-			[75.27, -43.35],
-			[75.00, -40.68],
-		// Oxenfurt
-			[41.74, 51.23],
-		// NE Velen
-			[2.48, -12.42],
-		// NW Velen
-			[-29.07, -106.97],
-			[-30.41, -73.01],
-			[-63.95, -75.66],
-			[-54.01, -122.37],
-			[-59.04, -143.61],
-		// SE Velen
-			[-35.53, 54.58],
-			[-33.60, -26.28],
-	], icons.armourerstable, 'Armorer\'s Table', '<h1>Armorer\'s Table</h1>Armorer\'s tables grant your gear increased armor for a limited duration'));
+		armourerstable: [{
+			coords: [
+				// Novigrad
+				[75.27, -43.35],
+				[75.00, -40.68],
+				// Oxenfurt
+				[41.74, 51.23],
+				// NE Velen
+				[2.48, -12.42],
+				// NW Velen
+				[-29.07, -106.97],
+				[-30.41, -73.01],
+				[-63.95, -75.66],
+				[-54.01, -122.37],
+				[-59.04, -143.61],
+				// SE Velen
+				[-35.53, 54.58],
+				[-33.60, -26.28]
+			],
+			label: "Armorer's Table",
+			popup: "Armorer\'s tables grant your gear increased armor for a limited duration"
+		}],
 
 	// Bandit Camp
-	var banditcampGeneric = genericMarkers([
-		// NE Velen
-			[11.61, -54.42],
-		// NW Velen
-			[-23.92, -95.51],
-			[-42.81, -128.14],
-			[-48.69, -130.78],
-			[-51.67, -133.59],
-			[-40.18, -136.49],
-			[-61.14, -145.81],
-			[-57.70, -154.75],
-		// SW Velen
-			[-64.55, -146.69],
-			[-65.04, -142.34],
-		// SE Velen
-			[-29.69, -17.23],
-	], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here');
-
-	markers.banditcamp = L.layerGroup($.merge(banditcampGeneric, [
-		// S Novigrad
-			createMarker([55.43, -63.00], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-		// E Novigrad
-			createMarker([74.40, 49.06], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 7)'),
-		// NE Velen
-			createMarker([0.53, 33.05], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-			createMarker([8.67, 1.76], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-		// SE Velen
-			createMarker([-77.24, 36.69], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 10)'),
-			createMarker([-53.33, 54.49], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-			createMarker([-26.90, 24.43], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-			createMarker([-38.96, -4.75], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 7-9)'),
-			createMarker([13.37, 84.36], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-			createMarker([-74.40, -6.81], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-		// SW Velen
-			createMarker([-69.81, -142.91], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here. Bugged area, never shows as cleared'),
-	]));
+		banditcamp: [{
+			coords: [
+				// NE Velen
+				[11.61, -54.42],
+				// NW Velen
+				[-23.92, -95.51],
+				[-42.81, -128.14],
+				[-48.69, -130.78],
+				[-51.67, -133.59],
+				[-40.18, -136.49],
+				[-61.14, -145.81],
+				[-57.70, -154.75],
+				// SW Velen
+				[-64.55, -146.69],
+				[-65.04, -142.34],
+				// SE Velen
+				[-29.69, -17.23],
+			],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here'
+		}, { // S Novigrad
+			coords: [[55.43, -63.00]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here (lvl 9)'
+		}, { // E Novigrad
+			coords: [[74.40, 49.06]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here (lvl 7)'
+		}, { // NE Velen
+			coords: [[0.53, 33.05]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here (lvl 9)'
+		}, {
+			coords: [[8.67, 1.76]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here (lvl 9)'
+		}, { // SE Velen
+			coords: [[-77.24, 36.69]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here (lvl 10)'
+		}, {
+			coords: [[-53.33, 54.49]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here (lvl 9)'
+		}, {
+			coords: [[-26.90, 24.43]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here (lvl 9)'
+		}, {
+			coords: [[-38.96, -4.75]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here (lvl 7-9)'
+		}, {
+			coords: [[13.37, 84.36]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here (lvl 9)'
+		}, {
+			coords: [[-74.40, -6.81]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here (lvl 9)'
+		}, { // SW Velen
+			coords: [[-69.81, -142.91]],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here. Bugged area, never shows as cleared'
+		}],
 
 	// Barber
-	markers.barber = L.layerGroup(genericMarkers([
-		// Novigrad
-			[76.45, -33.18],
-			[76.32, -20.39],
-		// Oxenfurt
-			[33.87, 52.12],
-		// NW Velen
-			[-54.36, -81.81],
-	], icons.barber, 'Barber', '<h1>Barber</h1>Visit barbers for a shave or a new haircut'));
+		barber: [{
+			coords: [
+				// Novigrad
+				[76.45, -33.18],
+				[76.32, -20.39],
+				// Oxenfurt
+				[33.87, 52.12],
+				// NW Velen
+				[-54.36, -81.81],
+			],
+			label: 'Barber',
+			popup: 'Visit barbers for a shave or a new haircut'
+		}],
 
 	// Blacksmith
-	markers.blacksmith = L.layerGroup([
-		// Novigrad
-			createMarker([69.15, -41.00], icons.blacksmith, 'Master Blacksmith*', '<h1>Master Blacksmith</h1>You must complete "Of Swords and Dumplings" (level 24) quest in order to unlock this blacksmith. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			createMarker([73.14, -37.96], icons.blacksmith, 'Journeyman Blacksmith', '<h1>Journeyman Blacksmith</h1>This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			createMarker([75.17, -43.15], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// Oxenfurt
-			createMarker([32.00, 59.77], icons.blacksmith, 'Journeyman Blacksmith', '<h1>Journeyman Blacksmith</h1>This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// NW Velen
-			createMarker([-29.27, -106.47], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			createMarker([-64.28, -75.87], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		// SE Velen
-			createMarker([-32.96, -26.91], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-	]);
+		blacksmith: [{ // Novigrad
+			coords: [[69.15, -41.00]],
+			label: 'Master Blacksmith*',
+			popupTitle: 'Master Blacksmith* (Hattori)',
+			popup: 'You must complete "Of Swords and Dumplings" (level 24) quest in order to unlock this blacksmith. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, {
+			coords: [[73.14, -37.96]],
+			label: 'Journeyman Blacksmith',
+			popup: 'This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, {
+			coords: [[75.17, -43.15]],
+			label: 'Amateur Blacksmith',
+			popup: 'This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // Oxenfurt
+			coords: [[32.00, 59.77]],
+			label: 'Journeyman Blacksmith',
+			popup: 'This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // NW Velen
+			coords: [[-29.27, -106.47]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, {
+			coords: [[-64.28, -75.87]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}, { // SE Velen
+			coords: [[-32.96, -26.91]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}],
 
 	// Brothel
-	markers.brothel = L.layerGroup([
-		// Novigrad
-			createMarker([71.22, -41.84], icons.brothel, 'Crippled Kate', '<h1>Crippled Kate Brothel</h1>You can call on the services of a prostitute here'),
-			createMarker([78.34, -33.40], icons.brothel, 'Passiflora', '<h1>Passiflora Brothel</h1>You can call on the services of a prostitute here')
-	]);
+		brothel: [{ // Novigrad
+			coords: [[71.22, -41.84]],
+			label: 'Crippled Kate',
+			popupTitle: 'Crippled Kate Brothel',
+			popup: 'You can call on the services of a prostitute here'
+		}, {
+			coords: [[78.34, -33.40]],
+			label: 'Passiflora',
+			popupTitle: 'Passiflora Brothel',
+			popup: 'You can call on the services of a prostitute here'
+		}],
 
 	// Boat
-/*
+		/* boat: [{
+			coords: [
+				// Novigrad
+				[69.84, -13.01],
+				[72.82, -10.28],
+				[77.92, -44.38],
+				[76.98, -47.29],
+				[76.92, -50.10],
+				[70.23, -46.47],
+				[70.03, -52.69],
+				[70.64, -58.93],
+				[73.64, -54.99],
+				[73.26, -52.57],
+				// NE Novigrad
+				[82.32, -53.51],
+				[81.33, -34.10],
+				// E Novigrad
+				[65.04, 19.78],
+				// S Novigrad
+				[67.41, -72.33],
+				[56.32, -3.89],
+				[47.36, -58.43],
+				[38.62, -61.56],
+				[30.83, -59.94],
+				[35.10, -28.19],
+				// Oxenfurt
+				[46.56, 49.37],
+				[36.03, 67.94],
+				[34.23, 61.00],
+				[28.23, 62.49],
+				[24.69, 54.23],
+				[29.38, 48.06],
+				[15.31, 68.73],
+				// NE Velen
+				[-7.19, 65.13],
+				[-0.97, 68.82],
+				[38.82, 39.55],
+				[51.45, 10.50],
+				[-19.10, 7.38],
+				[-18.40, -32.93],
+				// NW Velen
+				[-26.12, -31.38],
+				[-51.99, -34.10],
+				[-54.32, -54.32],
+				[-69.89, -33.44],
+				[-65.33, -64.47],
+				[-65.35, -81.43],
+				[-65.78, -82.31],
+				[-63.80, -125.46],
+				[-41.54, -142.82],
+				[-27.64, -121.82],
+				// SW Velen
+				[-73.48, -142.91],
+				[-74.04, -104.24],
+				[-77.06, -40.96],
+				[-71.90, -73.92],
+				[-80.18, -114.17],
+				// SE Velen
+				[-68.84, -4.48],
+			],
+			label: 'Boat',
+			popup: 'You can use boats to travel across bodies of water'
+		}], */
 
-
-	markers.boat = L.layerGroup(genericMarkers([
-		// Novigrad
-			[69.84, -13.01],
-			[72.82, -10.28],
-			[77.92, -44.38],
-			[76.98, -47.29],
-			[76.92, -50.10],
-			[70.23, -46.47],
-			[70.03, -52.69],
-			[70.64, -58.93],
-			[73.64, -54.99],
-			[73.26, -52.57],
-		// NE Novigrad
-			[82.32, -53.51],
-			[81.33, -34.10],
-		// E Novigrad
-			[65.04, 19.78],
-		// S Novigrad
-			[67.41, -72.33],
-			[56.32, -3.89],
-			[47.36, -58.43],
-			[38.62, -61.56],
-			[30.83, -59.94],
-			[35.10, -28.19],
-		// Oxenfurt
-			[46.56, 49.37],
-			[36.03, 67.94],
-			[34.23, 61.00],
-			[28.23, 62.49],
-			[24.69, 54.23],
-			[29.38, 48.06],
-			[15.31, 68.73],
-		// NE Velen
-			[-7.19, 65.13],
-			[-0.97, 68.82],
-			[38.82, 39.55],
-			[51.45, 10.50],
-			[-19.10, 7.38],
-			[-18.40, -32.93],
-		// NW Velen
-			[-26.12, -31.38],
-			[-51.99, -34.10],
-			[-54.32, -54.32],
-			[-69.89, -33.44],
-			[-65.33, -64.47],
-			[-65.35, -81.43],
-			[-65.78, -82.31],
-			[-63.80, -125.46],
-			[-41.54, -142.82],
-			[-27.64, -121.82],
-		// SW Velen
-			[-73.48, -142.91],
-			[-74.04, -104.24],
-			[-77.06, -40.96],
-			[-71.90, -73.92],
-			[-80.18, -114.17],
-		// SE Velen
-			[-68.84, -4.48],
-	], icons.boat, 'Boat', '<h1>Boat</h1>You can use boats to travel across bodies of water'));
-*/
 	// Entrance
-	// todo, entrance to what?
-	markers.entrance = L.layerGroup([
-		// Novigrad
-			createMarker([80.68, -55.02], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// NE Novigrad
-			createMarker([82.18, 32.78], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// SE Novigrad
-			createMarker([58.34, 66.68], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([61.02, 89.12], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([36.43, 114.21], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// S Novigrad
-			createMarker([53.96, -71.48], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// NE Velen
-			createMarker([27.06, -29.27], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// NW Velen
-			createMarker([3.05, -122.17], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-26.70, -63.75], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-28.77, -77.74], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// SW Velen
-			createMarker([-75.36, -124.19], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-76.32, -114.87], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		// SE Velen
-			createMarker([-71.64, -1.67], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-70.16, 39.55], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-48.52, -29.03], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-22.84, 72.02], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-56.51, 80.33], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-43.71, 39.20], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-35.32, 69.74], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-38.00, 70.36], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-79.628, 2.351], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-52.670, 31.069], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-			createMarker([-75.834, 50.361], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-	]);
+		// todo, entrance to what?
+		entrance: [{ // Novigrad
+			coords: [[80.68, -55.02]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // NE Novigrad
+			coords: [[82.18, 32.78]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // SE Novigrad
+			coords: [[58.34, 66.68]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[61.02, 89.12]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[36.43, 114.21]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // S Novigrad
+			coords: [[53.96, -71.48]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // NE Velen
+			coords: [[27.06, -29.27]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // NW Velen
+			coords: [[3.05, -122.17]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-26.70, -63.75]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-28.77, -77.74]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // SW Velen
+			coords: [[-75.36, -124.19]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-76.32, -114.87]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, { // SE Velen
+			coords: [[-71.64, -1.67]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-70.16, 39.55]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-48.52, -29.03]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-22.84, 72.02]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-56.51, 80.33]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-43.71, 39.20]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-35.32, 69.74]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-38.00, 70.36]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-79.628, 2.351]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-52.670, 31.069]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}, {
+			coords: [[-75.834, 50.361]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}],
 
 	// Grindstone
-	markers.grindstone = L.layerGroup(genericMarkers([
-		// Novigrad
-			[75.27, -42.95],
-			[74.96, -40.28],
-		// S Novigrad
-			[48.86, -51.39],
-		// Oxenfurt
-			[41.64, 51.53],
-		// NE Velen
-			[2.48, -13.42],
-		// NW Velen
-			[32.84, -114.26],
-			[-29.07, -105.97],
-			[-30.64, -72.55],
-			[-53.67, -80.20],
-			[-64.05, -75.06],
-			[-54.01, -123.57],
-			[-59.09, -144.05],
-		// SE Velen
-			[-35.89, 55.20],
-			[-33.80, -26.81],
-	], icons.grindstone, 'Grindstone', '<h1>Grindstone</h1>A blade sharpened here will deal more damage'));
+		grindstone: [{
+			coords: [
+				// Novigrad
+				[75.27, -42.95],
+				[74.96, -40.28],
+				// S Novigrad
+				[48.86, -51.39],
+				// Oxenfurt
+				[41.64, 51.53],
+				// NE Velen
+				[2.48, -13.42],
+				// NW Velen
+				[32.84, -114.26],
+				[-29.07, -105.97],
+				[-30.64, -72.55],
+				[-53.67, -80.20],
+				[-64.05, -75.06],
+				[-54.01, -123.57],
+				[-59.09, -144.05],
+				// SE Velen
+				[-35.89, 55.20],
+				[-33.80, -26.81],
+			],
+			label: 'Grindstone',
+			popup: 'A blade sharpened here will deal more damage'
+		}],
 
 	// Guarded Treasure
-	var guardedGeneric = genericMarkers([
-		// NE Velen
-			[22.51, -56.78],
-		// NW Velen
-			[-28.07, -119.66],
-			[-38.62, -123.40],
-			[-38.27, -149.24],
-		// SE Velen
-			[-73.42, 31.77],
-			[-51.78, -6.42],
-	], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
-
-	markers.guarded = L.layerGroup($.merge(guardedGeneric, [
-		// NE Novigrad
-			createMarker([76.43, -2.07], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'),
-			createMarker([80.52, -4.53], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 15<span> Bilge Hag</span>) guards a valuable cache here'),
-			createMarker([82.61, -33.49], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 23<span> Armored Arachas</span>) guards a valuable cache here'),
-		// SE Novigrad
-			createMarker([45.62, 99.05], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 20<span> Leshen</span>) guards a valuable cache here'),
-		// S Novigrad
-			createMarker([51.97, -12.00], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 18<span> Wyvern</span>) guards a valuable cache here'),
-			createMarker([62.00, -97.38], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 15<span> Noonwraith</span>) guards a valuable cache here'),
-		// NE Velen
-			createMarker([-8.93, 12.30], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 13<span> Alghoul</span>) guards a valuable cache here'),
-			createMarker([-7.89, 55.37], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 9<span> Drowners</span>) guards a valuable cache here'),
-		// NW Velen
-			createMarker([4.193, -82.463], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>Available after the \'Master Armorers\' (lvl 26) quest. A particularly powerful monster guards a valuable cache here'),
-			createMarker([-62.39, -118.17], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 7<span> Wraiths</span>) guards a valuable cache here'),
-			createMarker([-43.55, -40.08], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 14<span> Forktail</span>) guards a valuable cache here'),
-			createMarker([-45.61, -152.31], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 4<span> Drowners</span>) guards a valuable cache here'),
-			createMarker([25.96, -99.67], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 14<span> Basilisk</span>) guards a valuable cache here'),
-		// SW Velen
-			createMarker([-77.77, -102.04], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'),
-			createMarker([-81.30, -69.74], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 18<span> Noonwraith/Nightwraith</span>) guards a valuable cache here'),
-			createMarker([-82.20, -69.57], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 19<span> Gargoyle</span>) guards a valuable cache here'),
-			createMarker([-78.56, -48.91], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 13<span> Alghoul</span>) guards a valuable cache here'),
-		// SE Velen
-			createMarker([-70.260, 102.440], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 24<span> Earth Elemental</span>) guards a valuable cache here'),
-			createMarker([-75.81, 30.63], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 20<span> Bilge Hag</span>) guards a valuable cache here'),
-			createMarker([-80.190, 28.870], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 14<span> Wyvern</span>) guards a valuable cache here'),
-			createMarker([-81.11, 31.33], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 19<span> Cyclops</span>) guards a valuable cache here'),
-			createMarker([-63.27, 48.87], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'),
-	]));
+		guarded: [{
+			coords: [
+				// NE Velen
+					[22.51, -56.78],
+				// NW Velen
+					[-28.07, -119.66],
+					[-38.62, -123.40],
+					[-38.27, -149.24],
+				// SE Velen
+					[-73.42, 31.77],
+					[-51.78, -6.42],
+			],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster guards a valuable cache here'
+		}, { // NE Novigrad
+			coords: [[76.43, -2.07]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'
+		}, {
+			coords: [[80.52, -4.53]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 15<span> Bilge Hag</span>) guards a valuable cache here'
+		}, {
+			coords: [[82.61, -33.49]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 23<span> Armored Arachas</span>) guards a valuable cache here'
+		}, { // SE Novigrad
+			coords: [[45.62, 99.05]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 20<span> Leshen</span>) guards a valuable cache here'
+		}, { // S Novigrad
+			coords: [[51.97, -12.00]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 18<span> Wyvern</span>) guards a valuable cache here'
+		}, {
+			coords: [[62.00, -97.38]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 15<span> Noonwraith</span>) guards a valuable cache here'
+		}, { // NE Velen
+			coords: [[-8.93, 12.30]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 13<span> Alghoul</span>) guards a valuable cache here'
+		}, {
+			coords: [[-7.89, 55.37]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 9<span> Drowners</span>) guards a valuable cache here'
+		}, { // NW Velen
+			coords: [[4.193, -82.463]],
+			label: 'Guarded Treasure',
+			popup: 'Available after the \'Master Armorers\' (lvl 26) quest. A particularly powerful monster guards a valuable cache here'
+		}, {
+			coords: [[-62.39, -118.17]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 7<span> Wraiths</span>) guards a valuable cache here'
+		}, {
+			coords: [[-43.55, -40.08]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 14<span> Forktail</span>) guards a valuable cache here'
+		}, {
+			coords: [[-45.61, -152.31]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 4<span> Drowners</span>) guards a valuable cache here'
+		}, {
+			coords: [[25.96, -99.67]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 14<span> Basilisk</span>) guards a valuable cache here'
+		}, { // SW Velen
+			coords: [[-77.77, -102.04]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'
+		}, {
+			coords: [[-81.30, -69.74]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 18<span> Noonwraith/Nightwraith</span>) guards a valuable cache here'
+		}, {
+			coords: [[-82.20, -69.57]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 19<span> Gargoyle</span>) guards a valuable cache here'
+		}, {
+			coords: [[-78.56, -48.91]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 13<span> Alghoul</span>) guards a valuable cache here'
+		}, { // SE Velen
+			coords: [[-70.260, 102.440]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 24<span> Earth Elemental</span>) guards a valuable cache here'
+		}, {
+			coords: [[-75.81, 30.63]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 20<span> Bilge Hag</span>) guards a valuable cache here'
+		}, {
+			coords: [[-80.190, 28.870]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 14<span> Wyvern</span>) guards a valuable cache here'
+		}, {
+			coords: [[-81.11, 31.33]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 19<span> Cyclops</span>) guards a valuable cache here'
+		}, {
+			coords: [[-63.27, 48.87]],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'
+		}],
 
 	// Gwent Player
-	markers.gwent = L.layerGroup([
-		// Novigrad
-			createMarker([74.618, -35.132], icons.gwent, 'Gwent Player', '<h1>Book Merchant Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([71.00, -41.90], icons.gwent, 'Gwent Player', '<h1>Crippled Kate Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([78.25, -33.79], icons.gwent, 'Gwent Tournament', '<h1>Gwent Tournament (Quest)</h1>Find the scribe and sign up for the high-stakes Gwent tournament'),
-			createMarker([72.58, -26.21], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([70.15, -36.93], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([71.43, -35.51], icons.gwent, 'Gwent Player', '<h1>Herbalist Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([70.14, -1.45], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([70.00, -20.27], icons.gwent, 'Gwent Player', '<h1>Merchant Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([70.12, -29.16], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([73.32, -43.81], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([76.25, -23.95], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([73.20, -37.66], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([73.81, -37.76], icons.gwent, 'Gwent Player', '<h1>Banker Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([74.52, -46.63], icons.gwent, 'Gwent Player', '<h1>Fishmonger Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([75.37, -43.15], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([75.49, -44.62], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([76.87, -33.02], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([75.04, -20.82], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([75.39, -19.02], icons.gwent, 'Gwent Player', '<h1>Loan Shark Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([79.80, -49.53], icons.gwent, 'Gwent Player', '<h1>Alchemist Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([77.77, -15.58], icons.gwent, 'Gwent Player', '<h1>Alchemist Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([74.55, -32.41], icons.gwent, 'Gwent Player', '<h1>Innkeeper Player</h1>Warning, this player may disappear later in the game. Gamble your hard earned coin playing Gwent here'),
-		// S Novigrad
-			createMarker([62.43, -14.22], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-		// SE Novigrad
-			createMarker([50.64, 72.27], icons.gwent, 'Gwent Player', '<h1>Herbalist Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-		// Oxenfurt
-			createMarker([36.56, 52.47], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([38.92, 54.21], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([40.11, 51.68], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([32.20, 59.87], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-		// NE Velen
-			createMarker([2.58, -12.92], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-		// NW Velen
-			createMarker([-27.64, -102.54], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-28.87, -106.47], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-34.76, -72.57], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-31.90, -71.52], icons.gwent, 'Gwent Player', '<h1>Quartermaster Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-31.15, -70.82], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-28.39, -75.45], icons.gwent, 'Gwent Player', '<h1>Bloody Baron Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-52.60, -81.19], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-62.53, -76.44], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-54.27, -121.56], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-53.86, -122.97], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-30.67, -71.43], icons.gwent, 'Gwent Player', '<h1>Yoana (Armorer\'s assistant) Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-		// SE Velen
-			createMarker([-36.78, -24.15], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-32.76, -26.61], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-78.74, 108.44], icons.gwent, 'Gwent Player', '<h1>Quartermaster Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			createMarker([-57.20, 27.23], icons.gwent, 'Gwent Player', '<h1>Gwent Player</h1>This Gwent player disappears sometime after the \'Family matters\' quest. Gamble your hard earned coin playing Gwent here'),
-	]);
+		gwent: [{ // Novigrad
+			coords: [[74.618, -35.132]],
+			label: 'Gwent Player',
+			popupTitle: 'Book Merchant Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[71.00, -41.90]],
+			label: 'Gwent Player',
+			popupTitle: 'Crippled Kate Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[78.25, -33.79]],
+			label: 'Gwent Tournament',
+			popupTitle: 'Gwent Tournament (Quest)',
+			popup: 'Find the scribe and sign up for the high-stakes Gwent tournament'
+		}, {
+			coords: [[72.58, -26.21]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[70.15, -36.93]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[71.43, -35.51]],
+			label: 'Gwent Player',
+			popupTitle: 'Herbalist Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[70.14, -1.45]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[70.00, -20.27]],
+			label: 'Gwent Player',
+			popupTitle: 'Merchant Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[70.12, -29.16]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[73.32, -43.81]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[76.25, -23.95]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[73.20, -37.66]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[73.81, -37.76]],
+			label: 'Gwent Player',
+			popupTitle: 'Banker Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[74.52, -46.63]],
+			label: 'Gwent Player',
+			popupTitle: 'Fishmonger Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[75.37, -43.15]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[75.49, -44.62]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[76.87, -33.02]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[75.04, -20.82]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[75.39, -19.02]],
+			label: 'Gwent Player',
+			popupTitle: 'Loan Shark Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[79.80, -49.53]],
+			label: 'Gwent Player',
+			popupTitle: 'Alchemist Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[77.77, -15.58]],
+			label: 'Gwent Player',
+			popupTitle: 'Alchemist Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[74.55, -32.41]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Player',
+			popup: 'Warning, this player may disappear later in the game. Gamble your hard earned coin playing Gwent here'
+		}, { // S Novigrad
+			coords: [[62.43, -14.22]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, { // SE Novigrad
+			coords: [[50.64, 72.27]],
+			label: 'Gwent Player',
+			popupTitle: 'Herbalist Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, { // Oxenfurt
+			coords: [[36.56, 52.47]],
+			label: 'Gwent Player',
+			popupTitle: 'Innkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[38.92, 54.21]],
+			label: 'Gwent Player',
+			popupTitle: 'Armorer Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[40.11, 51.68]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[32.20, 59.87]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, { // NE Velen
+			coords: [[2.58, -12.92]],
+			label: 'Gwent Player',
+			popupTitle: 'Armorer Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, { // NW Velen
+			coords: [[-27.64, -102.54]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-28.87, -106.47]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-34.76, -72.57]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-31.90, -71.52]],
+			label: 'Gwent Player',
+			popupTitle: 'Quartermaster Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-31.15, -70.82]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-28.39, -75.45]],
+			label: 'Gwent Player',
+			popupTitle: 'Bloody Baron Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-52.60, -81.19]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-62.53, -76.44]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-54.27, -121.56]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-53.86, -122.97]],
+			label: 'Gwent Player',
+			popupTitle: 'Armorer Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-30.67, -71.43]],
+			label: 'Gwent Player',
+			popupTitle: "Yoana (Armorer's assistant) Gwent Player",
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, { // SE Velen
+			coords: [[-36.78, -24.15]],
+			label: 'Gwent Player',
+			popupTitle: 'Shopkeeper Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-32.76, -26.61]],
+			label: 'Gwent Player',
+			popupTitle: 'Blacksmith Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-78.74, 108.44]],
+			label: 'Gwent Player',
+			popupTitle: 'Quartermaster Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here'
+		}, {
+			coords: [[-57.20, 27.23]],
+			label: 'Gwent Player',
+			popupTitle: 'Gwent Player',
+			popup: 'This Gwent player disappears sometime after the \'Family matters\' quest. Gamble your hard earned coin playing Gwent here'
+		}],
 
 	// Harbor
-	markers.harbor = L.layerGroup(genericMarkers([
-		// Novigrad
-			[70.64, -58.93],
-		// Oxenfurt
-			[38.17, 46.85],
-		// NE Velen
-			[-6.53, 62.93],
-			[-19.10, 9.49],
-			[-18.40, -32.93],
-		// NW Velen
-			[-54.32, -54.32],
-			[-41.54, -142.82],
-			[-27.64, -121.82],
-		// SW Velen
-			[-71.90, -73.92],
-			[-80.18, -114.17],
-		// SE Velen
-			[-78.78, -11.07],
-	], icons.harbor, 'Harbor', '<h1>Harbor</h1>A place where you can find a boat, boats will respawn here'));
+		harbor: [{
+			coords: [
+				// Novigrad
+				[70.64, -58.93],
+				// Oxenfurt
+				[38.17, 46.85],
+				// NE Velen
+				[-6.53, 62.93],
+				[-19.10, 9.49],
+				[-18.40, -32.93],
+				// NW Velen
+				[-54.32, -54.32],
+				[-41.54, -142.82],
+				[-27.64, -121.82],
+				// SW Velen
+				[-71.90, -73.92],
+				[-80.18, -114.17],
+				// SE Velen
+				[-78.78, -11.07],
+			],
+			label: 'Harbor',
+			popup: 'A place where you can find a boat, boats will respawn here'
+		}],
 
 	// Herbalist
-	var herbalistGeneric = genericMarkers([
-		// Novigrad
-			[73.65, -34.89],
-			[71.33, -35.51],
-		// S Novigrad
-			[61.89, -13.16],
-		// SE Novigrad
-			[50.54, 72.07],
-	], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>Here you can buy alchemy ingredients');
-
-	markers.herbalist = L.layerGroup($.merge(herbalistGeneric, [
-		// NW Velen
-			createMarker([-50.26, -138.91], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
-			createMarker([-28.15, -135.26], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
-		// SW Velen
-			createMarker([-78.53, -41.44], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
-		// SE Velen
-			createMarker([-36.92, 2.37], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
-	]));
-
+		herbalist: [{
+			coords: [
+				// Novigrad
+				[73.65, -34.89],
+				[71.33, -35.51],
+				// S Novigrad
+				[61.89, -13.16],
+				// SE Novigrad
+				[50.54, 72.07],
+			],
+			label: 'Herbalist',
+			popup: 'Here you can buy alchemy ingredients'
+		}, { // NW Velen
+			coords: [[-50.26, -138.91]],
+			label: 'Herbalist',
+			popup: 'This merchant appears after liberating the area. Here you can buy alchemy ingredients'
+		}, {
+			coords: [[-28.15, -135.26]],
+			label: 'Herbalist',
+			popup: 'This merchant appears after liberating the area. Here you can buy alchemy ingredients'
+		}, { // SW Velen
+			coords: [[-78.53, -41.44]],
+			label: 'Herbalist',
+			popup: 'This merchant appears after liberating the area. Here you can buy alchemy ingredients'
+		}, { // SE Velen
+			coords: [[-36.92, 2.37]],
+			label: 'Herbalist',
+			popup: 'This merchant appears after liberating the area. Here you can buy alchemy ingredients'
+		}],
 
 	// Hidden Treasure
-	var hiddenGeneric = genericMarkers([
-		// NW Velen
-			[33.06, -115.25],
-			[-27.92, -128.06],
-			[-31.65, -143.17],
-			[-42.33, -140.33],
-		// SW Velen
-			[-71.34, -107.75],
-		// SE Velen
-			[-29.99, 28.39],
-	], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
-
-	markers.hidden = L.layerGroup($.merge(hiddenGeneric, [
-		// S Novigrad
-			createMarker([34.55, -43.68], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 6<span> Nekkers</span>)'),
-			createMarker([49.38, -68.91], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 15<span> Mucknixers</span>)'),
-		// NE Velen
-			createMarker([-16.89, 10.06], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 10<span> Drowners</span>)'),
-			createMarker([3.03, 64.56], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
-			createMarker([45.49, 26.76], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
-			createMarker([-3.51, 21.40], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Foglet</span>)'),
-			createMarker([52.35, 16.17], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 18<span> Bilge Hag</span>)'),
-			createMarker([47.72, 38.50], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 26+<span> Basilisk</span>)'),
-		// NW Velen
-			createMarker([-50.76, -155.04], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
-		// SE Velen
-			createMarker([-72.84, 77.08], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 22<span> Fiend</span>)'),
-			createMarker([-37.16, 97.29], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Foglets</span>)'),
-			createMarker([-20.96, 48.78], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 9<span> Bandits</span>)'),
-		// SW Velen
-			createMarker([-70.50, -150.64], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 25+<span> Grave Hag</span>)'),
-			createMarker([-72.78, -131.40], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 10<span> Bandits</span>)'),
-			createMarker([-71.09, -109.96], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 13<span> Wraiths</span>)'),
-			createMarker([-76.90, -80.68], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
-	]));
+		hidden: [{
+			coords: [
+				// NW Velen
+				[33.06, -115.25],
+				[-27.92, -128.06],
+				[-31.65, -143.17],
+				[-42.33, -140.33],
+				// SW Velen
+				[-71.34, -107.75],
+				// SE Velen
+				[-29.99, 28.39],
+			],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods'
+		},{ // S Novigrad
+			coords: [[34.55, -43.68]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 6<span> Nekkers</span>)'
+		}, {
+			coords: [[49.38, -68.91]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 15<span> Mucknixers</span>)'
+		}, { // NE Velen
+			coords: [[-16.89, 10.06]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 10<span> Drowners</span>)'
+		}, {
+			coords: [[3.03, 64.56]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'
+		}, {
+			coords: [[45.49, 26.76]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'
+		}, {
+			coords: [[-3.51, 21.40]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 4<span> Foglet</span>)'
+		}, {
+			coords: [[52.35, 16.17]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 18<span> Bilge Hag</span>)'
+		}, {
+			coords: [[47.72, 38.50]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 26+<span> Basilisk</span>)'
+		}, { // NW Velen
+			coords: [[-50.76, -155.04]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'
+		}, { // SE Velen
+			coords: [[-72.84, 77.08]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 22<span> Fiend</span>)'
+		}, {
+			coords: [[-37.16, 97.29]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 4<span> Foglets</span>)'
+		}, {
+			coords: [[-20.96, 48.78]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 9<span> Bandits</span>)'
+		}, { // SW Velen
+			coords: [[-70.50, -150.64]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 25+<span> Grave Hag</span>)'
+		}, {
+			coords: [[-72.78, -131.40]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 10<span> Bandits</span>)'
+		}, {
+			coords: [[-71.09, -109.96]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 13<span> Wraiths</span>)'
+		}, {
+			coords: [[-76.90, -80.68]],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'
+		}],
 
 	// Innkeep
-	markers.innkeep = L.layerGroup([
-		// Novigrad
-			createMarker([73.24, -44.21], icons.innkeep, 'The Golden Sturgen', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-			createMarker([78.22, -33.49], icons.innkeep, 'Passiflora', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-			createMarker([76.20, -24.35], icons.innkeep, 'The Nowhere', '<h1>Innkeep</h1>Sells Food and drink'),
-			createMarker([70.02, -29.56], icons.innkeep, 'Rosemary &amp; Thyme', '<h1>Innkeep</h1>Sells Food and drink'),
-			createMarker([70.04, -1.85], icons.innkeep, 'Seven Cats Inn', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-			createMarker([74.50, -32.61], icons.innkeep, 'The Kingfisher', '<h1>The Kingfisher</h1>Warning, this trader may disappear later in the game. Sells Gwent cards, food, and drink'),
-		// S Novigrad
-			createMarker([62.33, -14.02], icons.innkeep, 'Cunny of the Goose', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-		// Oxenfurt
-			createMarker([36.46, 52.27], icons.innkeep, 'The Alchemy', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-		// NE Velen
-			createMarker([0.09, -45.62], icons.innkeep, 'Inn at the Crossroads', '<h1>Innkeep</h1>Sells Gwent cards, and drink'),
-	]);
+		innkeep: [{ // Novigrad
+			coords: [[73.24, -44.21]],
+			label: 'The Golden Sturgen',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, food, and drink'
+		}, {
+			coords: [[78.22, -33.49]],
+			label: 'Passiflora',
+			popup: 'Sells Gwent cards, food, and drink'
+		}, {
+			coords: [[76.20, -24.35]],
+			label: 'The Nowhere',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Food and drink'
+		}, {
+			coords: [[70.02, -29.56]],
+			label: 'Rosemary &amp; Thyme',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Food and drink'
+		}, {
+			coords: [[70.04, -1.85]],
+			label: 'Seven Cats Inn',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, food, and drink'
+		}, {
+			coords: [[74.50, -32.61]],
+			label: 'The Kingfisher',
+			popupTitle: 'Innkeep',
+			popup: 'Warning, this trader may disappear later in the game. Sells Gwent cards, food, and drink'
+		}, { // S Novigrad
+			coords: [[62.33, -14.02]],
+			label: 'Cunny of the Goose',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, food, and drink'
+		}, { // Oxenfurt
+			coords: [[36.46, 52.27]],
+			label: 'The Alchemy',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, food, and drink'
+		}, { // NE Velen
+			coords: [[0.09, -45.62]],
+			label: 'Inn at the Crossroads',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, and drink'
+		}],
 
 	// Monster Den
-	var monsterdenGeneric = genericMarkers([
-		// NE Velen
-			[20.47, -13.76],
-		// SE Velen
-			[-54.47, 12.00],
-	], icons.monsterden, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby');
-
-	markers.monsterden = L.layerGroup($.merge(monsterdenGeneric, [
-		// NE Novigrad
-			createMarker([82.19, -32.08], icons.monsterden, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby (lvl 19<span> Golem</span>)'),
-		// S Novigrad
-			createMarker([46.99, -40.08], icons.monsterden, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby (lvl 16<span> Rabid Rock Troll</span> &amp; lvl 18<span> Nekkers</span>)'),
-	]));
+		monsterden: [{
+			coords: [
+				// NE Velen
+				[20.47, -13.76],
+				// SE Velen
+				[-54.47, 12.00],
+			],
+			label: 'Monster Den',
+			popup: 'Monster-infested location. A constant worry for those living nearby'
+		}, { // NE Novigrad
+			coords: [[82.19, -32.08]],
+			label: 'Monster Den',
+			popup: 'Monster-infested location. A constant worry for those living nearby (lvl 19<span> Golem</span>)'
+		}, { // S Novigrad
+			coords: [[46.99, -40.08]],
+			label: 'Monster Den',
+			popup: 'Monster-infested location. A constant worry for those living nearby (lvl 16<span> Rabid Rock Troll</span> &amp; lvl 18<span> Nekkers</span>)'
+		}],
 
 	// Monster Nest
-	var monsternestGeneric = genericMarkers([
-		// NE Velen
-			[33.87, 10.20],
-			[41.44, -0.79],
-		// NW Velen
-			[-23.97, -55.95],
-			[-36.56, -87.14],
-			[-53.38, -57.74],
-		// SW Velen
-			[-75.14, -122.29],
-			[-74.73, -121.49],
-		// SE Velen
-			[-68.69, -2.20],
-	], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
-
-	markers.monsternest = L.layerGroup($.merge(monsternestGeneric, [
-		// S Novigrad
-			createMarker([34.31, -60.51], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'),
-			createMarker([49.84, -45.97], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Endregas</span>)'),
-			createMarker([50.79, -42.19], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Endregas</span>)'),
-			createMarker([50.98, -20.99], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'),
-		// NE Velen
-			createMarker([7.36, 48.78], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'),
-			createMarker([8.01, 47.37], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'),
-			createMarker([-2.94, 27.38], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'),
-			createMarker([41.64, 13.97], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'),
-		// SW Velen
-			createMarker([-75.68, -27.11], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 4&amp;9<span> Drowners</span>)'),
-		// SE Velen
-			createMarker([-50.23, 57.57], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8<span> Nekkers</span>)'),
-			createMarker([-46.01, 52.56], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'),
-			createMarker([-49.04, 46.93], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'),
-			createMarker([-49.12, 42.36], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'),
-			createMarker([-40.18, 80.29], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 21<span> Wyvern</span>)'),
-			createMarker([-41.38, 80.38], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 21<span> Wyvern</span>)'),
-	]));
+		monsternest: [{
+			coords: [
+				// NE Velen
+				[33.87, 10.20],
+				[41.44, -0.79],
+				// NW Velen
+				[-23.97, -55.95],
+				[-36.56, -87.14],
+				[-53.38, -57.74],
+				// SW Velen
+				[-75.14, -122.29],
+				[-74.73, -121.49],
+				// SE Velen
+				[-68.69, -2.20],
+			],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs'
+		}, { // S Novigrad
+			coords: [[34.31, -60.51]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'
+		}, {
+			coords: [[49.84, -45.97]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Endregas</span>)'
+		}, {
+			coords: [[50.79, -42.19]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Endregas</span>)'
+		}, {
+			coords: [[50.98, -20.99]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'
+		}, { // NE Velen
+			coords: [[7.36, 48.78]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'
+		}, {
+			coords: [[8.01, 47.37]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'
+		}, {
+			coords: [[-2.94, 27.38]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'
+		}, {
+			coords: [[41.64, 13.97]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'
+		}, { // SW Velen
+			coords: [[-75.68, -27.11]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 4&amp;9<span> Drowners</span>)'
+		}, { // SE Velen
+			coords: [[-50.23, 57.57]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8<span> Nekkers</span>)'
+		}, {
+			coords: [[-46.01, 52.56]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'
+		}, {
+			coords: [[-49.04, 46.93]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'
+		}, {
+			coords: [[-49.12, 42.36]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'
+		}, {
+			coords: [[-40.18, 80.29]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 21<span> Wyvern</span>)'
+		}, {
+			coords: [[-41.38, 80.38]],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 21<span> Wyvern</span>)'
+		}],
 
 	// Notice Board
-	markers.notice = L.layerGroup(genericMarkers([
-		// Novigrad
-			[74.38, -34.06],
-			[73.00, -43.37],
-			[76.74, -32.21],
-			[64.42, -38.42],
-		// NE Novigrad
-			[82.13, 3.43],
-		// E Novigrad
-			[69.60, -1.93],
-			[73.07, 42.19],
-		// S Novigrad
-			[62.59, -16.70],
-		// Oxenfurt
-			[38.89, 52.29],
-		// NE Velen
-			[4.65, -12.04],
-			[1.14, -46.41],
-			[33.36, -21.18],
-		// NW Velen
-			[-54.19, -120.50],
-			[-31.50, -69.08],
-			[-63.51, -73.74],
-		// SE Velen
-			[-58.08, 27.95],
-			[-36.17, -26.02],
-			[-78.73, 110.17],
-	], icons.notice, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
+		notice: [{
+			coords: [
+				// Novigrad
+				[74.38, -34.06],
+				[73.00, -43.37],
+				[76.74, -32.21],
+				[64.42, -38.42],
+				// NE Novigrad
+				[82.13, 3.43],
+				// E Novigrad
+				[69.60, -1.93],
+				[73.07, 42.19],
+				// S Novigrad
+				[62.59, -16.70],
+				// Oxenfurt
+				[38.89, 52.29],
+				// NE Velen
+				[4.65, -12.04],
+				[1.14, -46.41],
+				[33.36, -21.18],
+				// NW Velen
+				[-54.19, -120.50],
+				[-31.50, -69.08],
+				[-63.51, -73.74],
+				// SE Velen
+				[-58.08, 27.95],
+				[-36.17, -26.02],
+				[-78.73, 110.17],
+			],
+			label: 'Notice Board',
+			popup: 'Here you can find monster contracts and announcements about matters of local concern'
+		}],
 
 	// Person in Distress
-	var pidGeneric = genericMarkers([
-		// NE Velen
-			[26.43, -11.87],
-		// NW Velen
-			[-33.94, -132.36],
-	], icons.pid, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance');
-
-	markers.pid = L.layerGroup($.merge(pidGeneric, [
-		// SE Novigrad
-			createMarker([20.47, 100.55], icons.pid, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance (lvl 9<span> Bandits</span>)'),
-		// NE Velen
-			createMarker([-17.64, -29.18], icons.pid, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance (lvl 10-16<span> Bandits</span>)'),
-		// NW Velen
-			createMarker([-61.23, -33.93], icons.pid, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance (lvl 5<span> Bandits</span>)'),
-	]));
+		pid: [{
+			coords: [
+				// NE Velen
+				[26.43, -11.87],
+				// NW Velen
+				[-33.94, -132.36],
+			],
+			label: 'Person(s) in Distress',
+			popup: "There's a person or a group of people here in need of assitance"
+		}, { // SE Novigrad
+			coords: [[20.47, 100.55]],
+			label: 'Person(s) in Distress',
+			popup: "There's a person or a group of people here in need of assitance (lvl 9<span> Bandits</span>)"
+		}, { // NE Velen
+			coords: [[-17.64, -29.18]],
+			label: 'Person(s) in Distress',
+			popup: "There's a person or a group of people here in need of assitance (lvl 10-16<span> Bandits</span>)"
+		}, { // NW Velen
+			coords: [[-61.23, -33.93]],
+			label: 'Person(s) in Distress',
+			popup: "There's a person or a group of people here in need of assitance (lvl 5<span> Bandits</span>)"
+		}],
 
 	// Place of Power
-	//todo get all place of power types
-	markers.pop = L.layerGroup([
-		// Novigrad
-			createMarker([80.72, -40.83], icons.pop, 'Place of Power', '<h1>Place of Power - Igni</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-		// E Novigrad
-			createMarker([71.02, 48.78], icons.pop, 'Place of Power', '<h1>Place of Power - Axii</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-		// NW Velen
-			createMarker([32.69, -112.60], icons.pop, 'Place of Power', '<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-		// SW Velen
-			createMarker([-82.85, -72.69], icons.pop, 'Place of Power', '<h1>Place of Power - Aard</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			createMarker([-71.82, -105.91], icons.pop, 'Place of Power*', '<h1>Place of Power - Yrden</h1>\'Wandering in the Dark\' quest. Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-		// SE Velen
-			createMarker([-78.19, 7.91], icons.pop, 'Place of Power', '<h1>Place of Power - todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			createMarker([-70.41, 38.41], icons.pop, 'Place of Power', '<h1>Place of Power - todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			createMarker([-55.68, 18.94], icons.pop, 'Place of Power', '<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			
-	]);
+		//todo get all place of power types
+		pop: [{ // Novigrad
+			coords: [[80.72, -40.83]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Igni',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, { // E Novigrad
+			coords: [[71.02, 48.78]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Axii',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, { // NW Velen
+			coords: [[32.69, -112.60]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Quen',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, { // SW Velen
+			coords: [[-82.85, -72.69]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Aard',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, {
+			coords: [[-71.82, -105.91]],
+			label: 'Place of Power*',
+			popupTitle: 'Place of Power - Yrden',
+			popup: '"Wandering in the Dark" quest. Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, { // SE Velen
+			coords: [[-78.19, 7.91]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - todo',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, {
+			coords: [[-70.41, 38.41]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - todo',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, {
+			coords: [[-55.68, 18.94]],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Yrden',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}],
 
 	// Point of Interest
-	markers.poi = L.layerGroup([
-		// Novigrad
-			createMarker([74.84, -25.88], icons.poi, 'Triss\' Residence', '<h1>Triss\' Residence</h1>todo'),
-			createMarker([70.12, -28.76], icons.poi, 'Dandelion &amp; Zoltan\'s Residence', '<h1>Dandelion &amp; Zoltan\'s Residence</h1>todo'),
-			createMarker([77.245, -24.829], icons.poi, 'Vilmerius Hospital', '<h1>Vilmerius Hospital</h1>todo'),
-		// NW Velen
-			createMarker([-47.34, -111.81], icons.poi, 'Keira Metz\'s Residence', '<h1>Keira Metz\'s Residence</h1>todo'),
-		// Velen
-			createMarker([61.90, -91.82], icons.poi, 'Witcher Upgrade Gear', '<h1>Feline Crossbow</h1>'),
-			createMarker([57.651, -30.169], icons.poi, 'Witcher Upgrade Gear', '<h1>Superior Feline Silver Sword</h1>'),
-			createMarker([75.70, -19.50], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Feline Silver Sword</h1>You need to climp up a Leader'),
-			createMarker([60.60, 89.80], icons.poi, 'Witcher Upgrade Gear', '<h1>Feline Silver Sword</h1>Inside the Est Tayiar Ruine, behind a Wall that you can break'),
-			createMarker([36.50, 114,50], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Feline Armor</h1>on top of the Aeramas’ Abandoned Manor'),
-			createMarker([33, -114.5], icons.poi, 'Witcher Upgrade Gear', '<h1>Griffin Silver Sword Diagram</h1>'),
-			createMarker([29.373, -73], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Griffin Boots</h1>'),
-			createMarker([41, -1], icons.poi, 'Witcher Upgrade Gear', '<h1>Griffin Steel Sword</h1>Near the Monster Nest'),
-			createMarker([36.5, 35], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhance Griffin Armor </h1> Near the Troll at White Eagle Fort'),
-			createMarker([22, 9.5], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhance Feline Gauntlets </h1>Inside a Shaft from the Codgers Quarry'),
-			createMarker([-28, -61], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Griffin Trousers </h1>Inside the Burned Ruin'),
-			createMarker([-57, -156], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Griffin Steel Sword </h1>'),
-			createMarker([-61, -8.5], icons.poi, 'Witcher Upgrade Gear', '<h1>Superior Feline Armor</h1>'),
-			createMarker([-54.5, 12], icons.poi, 'Witcher Upgrade Gear', '<h1>Griffin Armor Set</h1>Inside the Dragonslayers Grotto'),
-			createMarker([-64, 38], icons.poi, 'Witcher Upgrade Gear', '<h1>Superior Ursine Steel Sword</h1>Guarded by lvl 25<span> Earth Elemental</span>'),
-			createMarker([-81.1, 30.8], icons.poi, 'Witcher Upgrade Gear', '<h1>Mastercrafted Ursine Armor</h1>'),
-			createMarker([-75.6, -28], icons.poi, 'Witcher Upgrade Gear', '<h1>Mastercrafted Ursine Silver Sword </h1>'),
-			createMarker([-81.2, -70], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Griffin Gauntlets</h1>'),
-	]);
+		poi: [{ // Novigrad
+			coords: [[74.84, -25.88]],
+			label: "Triss's Residence",
+			popup: 'todo'
+		}, {
+			coords: [[70.12, -28.76]],
+			label: "Dandelion &amp; Zoltan's Residence",
+			popup: 'todo'
+		}, {
+			coords: [[77.245, -24.829]],
+			label: 'Vilmerius Hospital',
+			popup: 'todo'
+		}, { // NW Velen
+			coords: [[-47.34, -111.81]],
+			label: "Keira Metz's Residence",
+			popup: 'todo'
+		}, { // Velen
+			coords: [[61.90, -91.82]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Feline Crossbow',
+			popup: ''
+		}, {
+			coords: [[57.651, -30.169]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Superior Feline Silver Sword',
+			popup: ''
+		}, {
+			coords: [[75.70, -19.50]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Enhanced Feline Silver Sword',
+			popup: 'You need to climp up a Leader'
+		}, {
+			coords: [[60.60, 89.80]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Feline Silver Sword',
+			popup: 'Inside the Est Tayiar Ruine, behind a Wall that you can break'
+		}, {
+			coords: [[36.50, 114,50]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Enhanced Feline Armor',
+			popup: 'on top of the Aeramas’ Abandoned Manor'
+		}, {
+			coords: [[33, -114.5]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Griffin Silver Sword Diagram',
+			popup: ''
+		}, {
+			coords: [[29.373, -73]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Enhanced Griffin Boots',
+			popup: ''
+		}, {
+			coords: [[41, -1]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Griffin Steel Sword',
+			popup: 'Near the Monster Nest'
+		}, {
+			coords: [[36.5, 35]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Enhance Griffin Armor',
+			popup: ' Near the Troll at White Eagle Fort'
+		}, {
+			coords: [[22, 9.5]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Enhance Feline Gauntlets',
+			popup: 'Inside a Shaft from the Codgers Quarry'
+		}, {
+			coords: [[-28, -61]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Enhanced Griffin Trousers',
+			popup: 'Inside the Burned Ruin'
+		}, {
+			coords: [[-57, -156]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Enhanced Griffin Steel Sword',
+			popup: ''
+		}, {
+			coords: [[-61, -8.5]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Superior Feline Armor',
+			popup: ''
+		}, {
+			coords: [[-54.5, 12]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Griffin Armor Set',
+			popup: 'Inside the Dragonslayers Grotto'
+		}, {
+			coords: [[-64, 38]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Superior Ursine Steel Sword',
+			popup: 'Guarded by lvl 25<span> Earth Elemental</span>'
+		}, {
+			coords: [[-81.1, 30.8]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Mastercrafted Ursine Armor',
+			popup: ''
+		}, {
+			coords: [[-75.6, -28]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Mastercrafted Ursine Silver Sword',
+			popup: ''
+		}, {
+			coords: [[-81.2, -70]],
+			label: 'Witcher Upgrade Gear',
+			popupTitle: 'Enhanced Griffin Gauntlets',
+			popup: ''
+		}],
 
 	// Shopkeeper
-	markers.shopkeeper = L.layerGroup([
-		// Novigrad
-			createMarker([74.22, -35.41], icons.shopkeeper, 'Book Merchant', '<h1>Book Merchant</h1>Buys and sells books'),
-			createMarker([74.578, -35.332], icons.shopkeeper, 'Book Merchant', '<h1>Book Merchant</h1>Buys and sells books'),
-			createMarker([72.82, -39.99], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells alchemy supplies, food, and drink'),
-			createMarker([73.71, -37.96], icons.shopkeeper, 'Banker', '<h1>Banker</h1>You can exchange your unusable currency or borrow gold here'),
-			createMarker([69.90, -20.47], icons.shopkeeper, 'Clothing Merchant', '<h1>Clothing Merchant</h1>Sells clothes and masks'),
-			createMarker([70.05, -37.13], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies, weapons and \'Zerrikanian Saddlebags\' (+100)'),
-			createMarker([76.81, -33.26], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells alchemy supplies, quest items (for Aeramas\' Manor), and \'Potion of Clearance\' (1000 gold)'),
-			createMarker([75.41, -44.82], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells alchemy supplies, food, and drink'),
-			createMarker([74.47, -46.93], icons.shopkeeper, 'Fishmonger', '<h1>Fishmonger</h1>Sells fish'),
-			createMarker([76.57, -50.10], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells empty bottles'),
-			createMarker([76.12, -49.04], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones and alchemy supplies'),
-			createMarker([74.98, -20.57], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells nothing note worthy'),
-			createMarker([72.58, -26.41], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells gem dust (crafting supplies), weapons, food, and drink'),
-			createMarker([75.33, -19.28], icons.shopkeeper, 'Loan Shark', '<h1>Loan Shark</h1>Sells nothing note worthy'),
-			createMarker([75.61, -23.82], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies'),
-			createMarker([71.00, -41.60], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells food and drink'),
-		// NE Novigrad
-			createMarker([80.92, 50.49], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
-		// SE Novigrad
-			createMarker([3.43, 97.08], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears here after being rescued'),
-		// S Novigrad
-	// appears on my map but nobody there?
-	//				L.marker([65.95, -21.09], setMarker(icons.shopkeeper)).bindLabel('Shopkeeper'),
-			createMarker([58.677, -55.415], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Traveling from Lucian\'s Windmill to the Portside Gate. Sells runestones, alchemy supplies and food'),
-			createMarker([63.27, -63.46], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies, food, and weapons'),
-			createMarker([48.72, -51.94], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
-			createMarker([57.98, -12.00], icons.shopkeeper, 'Wandering Merchant', '<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
-		// Oxenfurt
-			createMarker([40.01, 51.48], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells paint (quest item), hides, and drink'),
-		// NE Velen
-			createMarker([26.00, 30.11], icons.shopkeeper, 'Wandering Merchant', '<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
-			createMarker([31.65, -17.93], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears here after being rescued. Sells alchemy supplies and food'),
-			createMarker([-6.84, 72.38], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells weapons and crafting supplies'),
-			createMarker([13.07, 46.27], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells runestones, alchemy supplies and food'),
-		// NW Velen
-			createMarker([-27.84, -102.74], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells nothing note worthy'),
-			createMarker([-34.96, -72.77], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells Gwent cards and drink'),
-			createMarker([-54.42, -121.65], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells Gwent cards and jewellery (crafting supplies)'),
-			createMarker([-47.04, -112.50], icons.shopkeeper, 'Keira Metz', '<h1>Keira Metz</h1>Sells alchemy supplies, recipes and \'Potion of Clearance\' (1000 gold)'),
-			createMarker([-32.03, -71.77], icons.shopkeeper, 'Quartermaster', '<h1>Quartermaster</h1>Sells Gwent cards, food, and drink'),
-			createMarker([-36.10, -72.51], icons.shopkeeper, 'Shopkeeper Anselm', '<h1>Shopkeeper Anselm</h1>This merchant appears here after being rescued. Sells \'Racing Horse Blinders\' (+40)'),
-			createMarker([-62.57, -76.89], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells drink and \'Rugged Saddlebags\' (+70)'),
-			createMarker([-52.70, -81.49], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells Gwent cards and drink'),
-			createMarker([-52.96, -56.65], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones and alchemy supplies'),
-			createMarker([-45.09, -138.96], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
-			createMarker([-58.36, -142.91], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
-		// SW Velen
-			createMarker([-79.58, -114.12], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells runestones, alchemy supplies and food'),
-		// SE Velen
-			createMarker([-36.17, 3.69], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears here after being rescued. Sells alchemy supplies and food'),
-			createMarker([-36.88, -24.35], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells Gwent cards, and crafting supplies'),
-			createMarker([-37.79, -26.19], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
-			createMarker([-78.79, 108.24], icons.shopkeeper, 'Quartermaster', '<h1>Quartermaster</h1>Sells nothing note worthy'),
-			createMarker([-57.35, 27.03], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant disappears sometime after the \'Family matters\' quest. Sells drink'),
-			createMarker([-76.16, 107.67], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones and alchemy supplies'),
-			createMarker([-75.93, 110.28], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
-			createMarker([-75.50, 110.81], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells weapons and crafting supplies'),
-		
-	]);
+		shopkeeper: [{ // Novigrad
+			coords: [[74.22, -35.41]],
+			label: 'Book Merchant',
+			popup: 'Buys and sells books'
+		}, {
+			coords: [[74.578, -35.332]],
+			label: 'Book Merchant',
+			popup: 'Buys and sells books'
+		}, {
+			coords: [[72.82, -39.99]],
+			label: 'Shopkeeper',
+			popup: 'Sells alchemy supplies, food, and drink'
+		}, {
+			coords: [[73.71, -37.96]],
+			label: 'Banker',
+			popup: 'You can exchange your unusable currency or borrow gold here'
+		}, {
+			coords: [[69.90, -20.47]],
+			label: 'Clothing Merchant',
+			popup: 'Sells clothes and masks'
+		}, {
+			coords: [[70.05, -37.13]],
+			label: 'Shopkeeper',
+			popup: 'Sells crafting supplies, weapons and "Zerrikanian Saddlebags" (+100)'
+		}, {
+			coords: [[76.81, -33.26]],
+			label: 'Shopkeeper',
+			popup: 'Sells alchemy supplies, quest items (for Aeramas\' Manor), and "Potion of Clearance" (1000 gold)'
+		}, {
+			coords: [[75.41, -44.82]],
+			label: 'Shopkeeper',
+			popup: 'Sells alchemy supplies, food, and drink'
+		}, {
+			coords: [[74.47, -46.93]],
+			label: 'Fishmonger',
+			popup: 'Sells fish'
+		}, {
+			coords: [[76.57, -50.10]],
+			label: 'Shopkeeper',
+			popup: 'Sells empty bottles'
+		}, {
+			coords: [[76.12, -49.04]],
+			label: 'Shopkeeper',
+			popup: 'Sells runestones and alchemy supplies'
+		}, {
+			coords: [[74.98, -20.57]],
+			label: 'Shopkeeper',
+			popup: 'Sells nothing note worthy'
+		}, {
+			coords: [[72.58, -26.41]],
+			label: 'Shopkeeper',
+			popup: 'Sells gem dust (crafting supplies), weapons, food, and drink'
+		}, {
+			coords: [[75.33, -19.28]],
+			label: 'Loan Shark',
+			popup: 'Sells nothing note worthy'
+		}, {
+			coords: [[75.61, -23.82]],
+			label: 'Shopkeeper',
+			popup: 'Sells crafting supplies'
+		}, {
+			coords: [[71.00, -41.60]],
+			label: 'Shopkeeper',
+			popup: 'Sells food and drink'
+		}, { // NE Novigrad
+			coords: [[80.92, 50.49]],
+			label: 'Shopkeeper',
+			popup: 'Sells runestones, alchemy supplies and food'
+		}, { // SE Novigrad
+			coords: [[3.43, 97.08]],
+			label: 'Shopkeeper',
+			popup: 'This merchant appears here after being rescued'
+		}, /*{ // S Novigrad
+			// appears on map but nobody there?
+			coords: [[65.95, -21.09]],
+			label: 'Shopkeeper',
+			popup: '???'
+		},*/ {
+			coords: [[58.677, -55.415]],
+			label: 'Wandering Merchant',
+			popup: 'Traveling from Lucian\'s Windmill to the Portside Gate. Sells runestones, alchemy supplies and food'
+		}, {
+			coords: [[63.27, -63.46]],
+			label: 'Shopkeeper',
+			popup: 'Sells crafting supplies, food, and weapons'
+		}, {
+			coords: [[48.72, -51.94]],
+			label: 'Shopkeeper',
+			popup: 'Sells armour and crafting supplies'
+		}, {
+			coords: [[57.98, -12.00]],
+			label: 'Wandering Merchant',
+			popupTitle: 'Shopkeeper',
+			popup: 'Sells runestones, alchemy supplies and food'
+		}, { // Oxenfurt
+			coords: [[40.01, 51.48]],
+			label: 'Shopkeeper',
+			popup: 'Sells paint (quest item), hides, and drink'
+		}, { // NE Velen
+			coords: [[26.00, 30.11]],
+			label: 'Wandering Merchant',
+			popupTitle: 'Shopkeeper',
+			popup: 'Sells runestones, alchemy supplies and food'
+		}, {
+			coords: [[31.65, -17.93]],
+			label: 'Shopkeeper',
+			popup: 'This merchant appears here after being rescued. Sells alchemy supplies and food'
+		}, {
+			coords: [[-6.84, 72.38]],
+			label: 'Shopkeeper',
+			popup: 'This merchant appears after liberating the area. Sells weapons and crafting supplies'
+		}, {
+			coords: [[13.07, 46.27]],
+			label: 'Shopkeeper',
+			popup: 'This merchant appears after liberating the area. Sells runestones, alchemy supplies and food'
+		}, { // NW Velen
+			coords: [[-27.84, -102.74]],
+			label: 'Shopkeeper',
+			popup: 'Sells nothing note worthy'
+		}, {
+			coords: [[-34.96, -72.77]],
+			label: 'Shopkeeper',
+			popup: 'Sells Gwent cards and drink'
+		}, {
+			coords: [[-54.42, -121.65]],
+			label: 'Shopkeeper',
+			popup: 'Sells Gwent cards and jewellery (crafting supplies)'
+		}, {
+			coords: [[-47.04, -112.50]],
+			label: 'Keira Metz',
+			popup: 'Sells alchemy supplies, recipes and "Potion of Clearance" (1000 gold)'
+		}, {
+			coords: [[-32.03, -71.77]],
+			label: 'Quartermaster',
+			popup: 'Sells Gwent cards, food, and drink'
+		}, {
+			coords: [[-36.10, -72.51]],
+			label: 'Shopkeeper Anselm',
+			popup: 'This merchant appears here after being rescued. Sells "Racing Horse Blinders" (+40)'
+		}, {
+			coords: [[-62.57, -76.89]],
+			label: 'Shopkeeper',
+			popup: 'Sells drink and "Rugged Saddlebags" (+70)'
+		}, {
+			coords: [[-52.70, -81.49]],
+			label: 'Shopkeeper',
+			popup: 'Sells Gwent cards and drink'
+		}, {
+			coords: [[-52.96, -56.65]],
+			label: 'Shopkeeper',
+			popup: 'Sells runestones and alchemy supplies'
+		}, {
+			coords: [[-45.09, -138.96]],
+			label: 'Shopkeeper',
+			popup: 'Sells armour and crafting supplies'
+		}, {
+			coords: [[-58.36, -142.91]],
+			label: 'Shopkeeper',
+			popup: 'Sells armour and crafting supplies'
+		}, { // SW Velen
+			coords: [[-79.58, -114.12]],
+			label: 'Shopkeeper',
+			popup: 'This merchant appears after liberating the area. Sells runestones, alchemy supplies and food'
+		}, { // SE Velen
+			coords: [[-36.17, 3.69]],
+			label: 'Shopkeeper',
+			popup: 'This merchant appears here after being rescued. Sells alchemy supplies and food'
+		}, {
+			coords: [[-36.88, -24.35]],
+			label: 'Shopkeeper',
+			popup: 'Sells Gwent cards, and crafting supplies'
+		}, {
+			coords: [[-37.79, -26.19]],
+			label: 'Shopkeeper',
+			popup: 'Sells runestones, alchemy supplies and food'
+		}, {
+			coords: [[-78.79, 108.24]],
+			label: 'Quartermaster',
+			popup: 'Sells nothing note worthy'
+		}, {
+			coords: [[-57.35, 27.03]],
+			label: 'Shopkeeper',
+			popup: 'This merchant disappears sometime after the "Family Matters" quest. Sells drink'
+		}, {
+			coords: [[-76.16, 107.67]],
+			label: 'Shopkeeper',
+			popup: 'Sells runestones and alchemy supplies'
+		}, {
+			coords: [[-75.93, 110.28]],
+			label: 'Shopkeeper',
+			popup: 'Sells armour and crafting supplies'
+		}, {
+			coords: [[-75.50, 110.81]],
+			label: 'Shopkeeper',
+			popup: 'Sells weapons and crafting supplies'
+		}],
 
 	// Sign Post
-	markers.signpost = L.layerGroup([
-		// Novigrad
-			createMarker([73.76, -33.97], icons.signpost, 'Hierarch Square', '<h1>Hierarch Square</h1>Until quite recently a great many mages lived near Novigrad\'s main square. They fled when the witch hunters began their reign of terror, leaving many of the city\'s most beautiful townhouses abandoned and uncared for'),
-			createMarker([74.23, -15.86], icons.signpost, 'Southern Gate', '<h1>Southern Gate</h1>In truth demarcating the eastern and not southern edge of the city, the Southern Gate was given its inappropriate name by a one-time city planner who knew nothing about architecture and could not read a map, but had in his favor the fact that he was the mayor\'s cousin and thew lavish parties. Though confusingly incorrect, the name stuck and now the city\'s residents never think twice about its illogical appellation'),
-			createMarker([76.44, -16.20], icons.signpost, 'Oxenfurt Gate', '<h1>Oxenfurt Gate</h1>In the times when Novigrad and Oxenfurt were embroiled in fierce neighborly disputes, this gate went through several completely different names, the Gate of Harlots and the Gate of Bloodsuckers being two of the longer lived examples. Its current name was chosen when this conflict was finally put to rest'),
-			createMarker([77.64, -36.47], icons.signpost, 'St. Gregory\'s Bridge', '<h1>St. Gregory\'s Bridge</h1>Bridge named after the hero of Novigrad who saved the city from a horrible famine three hundred years ago by sacrificing half his fortune to import food from Nazair. After this, he was declared a saint, something even the jurors of the Church of the Eternal Fire were unable to change'),
-			createMarker([79.73, -51.24], icons.signpost, 'Electors\' Square', '<h1>Electors\' Square</h1>Square named after a group of Novigrad reformers who enacted bold transformations that led to the city\'s rapid growth, enriching its residents considerably and ushering in the city\'s golden age'),
-			createMarker([71.16, -22.94], icons.signpost, 'Tretogor Gate', '<h1>Tretogor Gate</h1>Gate erected with funds from the Redanian royal family, who, wanting to earn favor with Novigrad merchants and the hierach, dedicated a significant amount of coin to its construction, as well as some no-less-valuable (wo)manpower in the form of the master architect Countess Anna Yaye-Pinkovitz and her skilled crew'),
-			createMarker([68.94, -27.77], icons.signpost, 'Gate of the Hierarch', '<h1>Gate of the Hierarch</h1>This gate is named in honor of Novigrad\'s own son, the Hierach of the eternal Fire. Supposedly this name was given to it upon popular request, though no one can be found who remembers requesting any such thing'),
-			createMarker([66.32, -35.31], icons.signpost, 'Glory Gate', '<h1>Glory Gate</h1>Toughs and hooligans often end a night of drunken escapades under this gate after being thrown out of the nearby taverns'),
-			createMarker([65.99, -43.90], icons.signpost, 'Portside Gate', '<h1>Portside Gate</h1>Though not the most stately of gates, this one\'s location near the bustling port has made it the calling card of the city'),
-			createMarker([69.57, -55.28], icons.signpost, 'Novigrad Docks', '<h1>Novigrad Docks</h1>A den of dirt and depravity and the shadiest part of Novigrad. After dark all one finds here are women of loose morals, hoodlums and drunk sailors'),
-			createMarker([75.39, -8.88], icons.signpost, 'Arette', '<h1>Arette</h1>Novigrad has always attracted those in search of a better life. Some of them found no welcome within the city walls, and so built huts outside the city'),
-			createMarker([69.57, -2.81], icons.signpost, 'Seven Cats Inn', '<h1>Seven Cats Inn</h1>This dank establishment is host to a shady clientele'),
-		// NE Novigrad
-			createMarker([83.53, -9.40], icons.signpost, 'Sarrasin Grange', '<h1>Sarrasin Grange</h1>Lord Antares Sarrasin moved his wife and smattering of comely daughters here from far-off Nazair on his medic\'s recommendations. The leech proclaimed with absolute certainy that "if you wish to sire a son, it must be in the Gustfields." While waiting to produce a male heir, the Sarrasins took to wine cultivation and soon their grange became renowned from Nazair to Skellige'),
-			createMarker([81.92, 3.60], icons.signpost, 'Yantra', '<h1>Yantra</h1>The inhabitants of this village are known for their talkativeness and tendency to exagerrate, which makes them good companions for a round of drink, but impossible to tolerate for long stretches of time'),
-			createMarker([82.09, 30.15], icons.signpost, 'Isolated Hut', '<h1>Isolated Hut</h1>Rumors claim a famous painter lives in this house, though no one has ever seen him or knows his name'),
-			createMarker([76.24, 18.26], icons.signpost, 'Honeyfill Meadworks', '<h1>Honeyfill Meadworks</h1>The renowned Honeyfill Meadworks has for generations belonged to a respected family of halflings'),
-			createMarker([79.04, 65.21], icons.signpost, 'Martin Feuille\'s Farmstead', '<h1>Martin Feuille\'s Farmstead</h1>Founded by Lord Martin Feuille, this vast plantation was until not so long ago the largest producer of alfalfa in the region. Sadly, when war broke out the lord fled to his winter residence in Kovir, leaving his land to be administered by an ill-suited stward who squandered his liege\'s fertile fields'),
-			createMarker([81.02, 49.09], icons.signpost, 'Winespring Grange', '<h1>Winespring Grange</h1>Years ago, an eccentric count named Jacobus Ruth of the Rieslings settled here. The count could not stand the pomposity of court life but loved good wine. He thus planted a vineyard here which produces a fabulous beaujolais prized on both sides of the Pontar'),
-			createMarker([79.59, 31.03], icons.signpost, 'Moldavie Residence', '<h1>Moldavie Residence</h1>Despite its ideal location and beautiful surroundings, this residence has been tossed from owner to owner like a hot potato, and for some unknown reason suffers from a bad reputation'),
-			createMarker([81.66, -31.55], icons.signpost, 'Cavern', '<h1>Cavern</h1>One of those places wise men avoid at all costs, so as not to tempt fate'),
-		// E Novigrad
-			createMarker([72.92, 41.31], icons.signpost, 'Alness', '<h1>Alness</h1>Until recently, this was a thoroughly unremarkable village. then the Vegelbuds began organizing their famous horse races here, granting Alness the enviable honor of hosting the region\'s most pretigious equestrian contests'),
-			createMarker([67.58, 31.03], icons.signpost, 'Wheat Fields', '<h1>Wheat Fields</h1>The fertile soils of the Pontar delta guarantee the inhabitants of Novigrad full granaries and full stomaches all year long'),
-			createMarker([65.31, 46.67], icons.signpost, 'Vegelbud Residence', '<h1>Vegelbud Residence</h1>Domicile of a prominent Novigrad family whose line can be traced back to the times when the first human settlers came to these lands'),
-		// SE Novigrad
-			createMarker([62.02, 39.11], icons.signpost, 'Carsten', '<h1>Carsten</h1>A village named after a baker whose exquisite goods gained him fame, as well as the privilege of supplying bread to the table of the hierarch of the Church of the Eternal Fire in Novigrad. Following his death, none proved capable of recreating his recipes for his delicious and depply aromatic breads, so these days Carsten is known chiefly for its trade in grain and flour'),
-			createMarker([58.56, 66.27], icons.signpost, 'Temerian Partisan Hideout', '<h1>Temerian Partisan Hideout</h1>Though the Nilfgaardians thought Temeria died along with King Foltest, Temerian guerillas still hide in the woods, prepared to give their lives at a moment\'s notice in their fight for independence'),
-			createMarker([59.82, 85.87], icons.signpost, 'Est Tayiar', '<h1>Est Tayiar</h1>Long before men first peopled these lands, a beautiful, prospering elven city stood here, centered around the palace of King Maeglor. One day, however, the city\'s inhabitants began mysteriously dying off in large numbers. According to legend, King Maeglor sensed he, too, would soon perish and cast a powerful spell that caused the earth to swallow the city whole so that no outsider could ever desecrate it. Centuries later, scholars from the Oxenfurt Academy began painstaking excavations of King Maeglor\'s palace in a search for the causes of the catastrophe. Yet work came to a sudden halt when three subsequent expeditions ventured into the ruins\' depths - and were never heard from again...'),
-			createMarker([49.45, 70.67], icons.signpost, 'Herbalist\'s Hut', '<h1>Herbalist\'s Hut</h1>Home to a halfling herbalist who is a passionate devotee of innovative gardening methods and experimental herbal medicine'),
-			createMarker([35.51, 110.67], icons.signpost, 'Aeramas\' Abandoned Manor', '<h1>Aeramas\' Abandoned Manor</h1>Peasants living nearby often complain about the overwhelming cheese stench wafting out of this residence...'),
-			createMarker([19.89, 83.06], icons.signpost, 'Crossroads', '<h1>Crossroads</h1>A small crossroads in the woods'),
-			createMarker([49.85, 52.73], icons.signpost, 'Gustfields Farm', '<h1>Gustfields Farm</h1>Farmstead founded years ago by an eccentric flaxen-haired painter named Cunigund de Cabbrae, who came here seeking peace, quiet and fresh country air'),
-			createMarker([76.64, 37.00], icons.signpost, 'Dancing Windmill', '<h1>Dancing Windmill</h1>When the current owner\'s grandfather, the famous dancer Pablo "Sugar" Sasko, ended his career, he settled here and organised nights of dancing for the nearby peasantry. Supposedly these revelries became so fashionable that dung-booted peasants were dancing rounds with members of Novigrad\'s most elite familes and adventure-seeking urban dandies'),
-		// S Novigrad
-			createMarker([67.20, -65.48], icons.signpost, 'Loggers Hut', '<h1>Loggers Hut</h1>A lone cabin deep in the Novigrad Forest - an ideal base for woodcutters'),
-			createMarker([66.92, -85.25], icons.signpost, 'Lighthouse', '<h1>Lighthouse</h1>Many years ago a horrible accident took place here: a ship carrying the cousin of King Radovid IV the Bald wrecked against the rocks during a storm. The king ordered a lighthouse erected on that spot in order to warn other seafarers of its deadly danger'),
-			createMarker([61.90, -14.08], icons.signpost, 'Cunny of the Goose', '<h1>Cunny of the Goose</h1>This inn owes its name to its former owner, a swaggering, blustering fellow who wanted to attract those of a similar temperatment. Luckily he died of liver poisoning after a few years and ownership passed to a distant relative, who turned the Cunny of the Goose into the best spot for stuffed goose liver in all the region'),
-			createMarker([58.03, -29.44], icons.signpost, 'Drahim Castle', '<h1>Drahim Castle</h1>In its glory years, this castle was home to the Redanian Moskovitz of the Sea Cats dynasty, patrons of the arts and admirers of elven culture. After the death by suicide of the dynasty\'s last member, Prince Adrien, the castle fell into the hands of the Redanian crown - and then into ruin'),
-			createMarker([54.10, -71.98], icons.signpost, 'Widows\' Grotto', '<h1>Widows\' Grotto</h1>According to legend, many years ago a young woman would wait here and watch for her husband\'s return from an overseas raid. Years passed and the woman grew old, still waiting for her husband. Yet he never came, and finally, she died. Three days after her funeral, her husband returned, having at last escaped from the pirates who had held him captive all that time. When he learned about his beloved\'s loyal vigil, he wept bitter tears, then lept to his death'),
-			createMarker([45.98, -51.33], icons.signpost, 'Ursten', '<h1>Ursten</h1>War has caused countless refugees to flee Temeria. With the Pontar blockaded, they have tended to flood villages which, like Ursten, are located close to river crossings'),
-			createMarker([60.50, -55.55], icons.signpost, 'Lucian\'s Windmill', '<h1>Lucian\'s Windmill</h1>Lucian le Foix, the famous Oxenfurt sculptor and architect, bought this windmill several years ago and made it into his country retreat. Sadly the enormous popularity of the great Lucian\'s designs means he spends little time in his fortress of solitude and has entrusted its care to a steward'),
-			createMarker([62.35, 11.69], icons.signpost, 'Eternal Fire Chapel', '<h1>Eternal Fire Chapel</h1>This shrine greets travelers on their way to Oxenfurt. Merchants sometimes stop here to sell goods to pilgrims and visiting scholars'),
-			createMarker([37.11, -27.23], icons.signpost, 'Border Post', '<h1>Border Post</h1>A small isle stuck in the river\'s central current - an ideal place for bleaching cloth'),
-		// Oxenfurt
-			createMarker([38.17, 62.31], icons.signpost, 'Novigrad Gate', '<h1>Novigrad Gate</h1>During Oxenfurt Academy\'s exam sessions, this gate would be closed, to spare the students from Novigrad\'s temptations'),
-			createMarker([29.10, 52.58], icons.signpost, 'Western Gate', '<h1>Western Gate</h1>Before war broke out, several hundred people a day would pass through here. Now the Redanian blockade has slowed traffic to a mere trickle'),
-			createMarker([37.40, 48.34], icons.signpost, 'Oxenfurt Harbor', '<h1>Oxenfurt Harbor</h1>Oxenfurt\'s picturesque port has featured as the subject of numerous odes and ballads, the setting for at least three lurid crime novels, and a favorite spot for romantic outings for generations of students'),
-		// NE Velen
-			createMarker([15.62, 25.66], icons.signpost, 'Stonecutters\' Settlement', '<h1>Stonecutters\' Settlement</h1>Over Twenty years ago a certain Bartolomeo, known as "Badger" on account of certain characteristic aspects of his coiffure, discovered a rich deposit of high-quality stone on this spot. He bought the land for a song, then leased it back to local peasants before heading off to Kovir, where he lives the life of a rich and powerful townsman to this day'),
-			createMarker([35.96, 34.41], icons.signpost, 'White Eagle Fort', '<h1>White Eagle Fort</h1>The grand name might seem in ill-fitting with this place, but the troll that lives here - a Redanian patriot and military aficionado - goes to great lengths to make his beloved King Radovid proud'),
-			createMarker([27.45, 12.00], icons.signpost, 'Codgers\' Quarry', '<h1>Codgers\' Quarry</h1>The now-inactive quarry once only employed stonebreakers over thirty years of age who would work hard all day, then spend the evenings racing down the sides of the quarry pit on hand-crafted wagons'),
-			createMarker([39.61, -2.42], icons.signpost, 'Hindhold', '<h1>Hindhold</h1>This watchtower used to protect barges traveling between Oxenfurt and Novigrad. It once even boasted a bridge connecting the two sides of the river, but now it stands abandoned and neglected, its bridge a collapsed ruin'),
-			createMarker([-4.01, 63.37], icons.signpost, 'Ferry Station', '<h1>Ferry Station</h1>The ferry\'s former owners were famed for treating travelers who were forced to wait for better conditions to raucous and unforgettable evenings'),
-			createMarker([13.75, -9.05], icons.signpost, 'Hanged Man\'s Tree', '<h1>Hanged Man\'s Tree</h1>During the war, both sides committed acts of exorbitant cruelty meant to keep the conquered populaces in check'),
-			createMarker([5.22, 5.41], icons.signpost, 'Devil\'s Pit', '<h1>Devil\'s Pit</h1>The inhabitants of Velen believe the expanse of caverns underneath the Devil\'s Pit are home to demons'),
-			createMarker([1.43, -15.16], icons.signpost, 'Mulbrydale', '<h1>Mulbrydale</h1>One of the oldest villages in the region. Owes its name to a certain undereducated botanist who could not discern one kind of tree from another and so called them all mulberries'),
-			createMarker([0.82, -47.20], icons.signpost, 'Inn at the Crossroads', '<h1>Inn at the Crossroads</h1>A sizeable establishment able to accommodate a crowd of travelers and revelers'),
-		// NW Velen
-			createMarker([21.78, -106.54], icons.signpost, 'Harpy Feeding Ground', '<h1>Harpy Feeding Ground</h1>One of those places entered by only the very brave, or very foolish'),
-			createMarker([30.56, -114.31], icons.signpost, 'Lornruk', '<h1>Lornruk</h1>Years ago smugglers would come here to load and unload illicit cargo'),
-			createMarker([-1.85, -98.61], icons.signpost, 'Heatherton', '<h1>Heatherton</h1>The inhabitants of this village were relieved when they learned the path of the marching armies had shifted slightly and passed their village bye. Then, one night... they changed their mind'),
-			createMarker([0.97, -110.39], icons.signpost, 'Abandoned Tower', '<h1>Abandoned Tower</h1>Legend has it a beleaguered traveler once stood at this tower\'s gates. He begged for shelter for the night, claiming he\'d been injured, but the baron living inside was afraid the traveler was a spy and sent him away. Little did he know the traveler was a powerful mage, who cast a curse on the tower, its inhospitable owner and all who dwelled with him. Soon thereafter the baron and all his retinue died in mysterious circumstances, and the tower fell into ruin'),
-			createMarker([2.37, -122.34], icons.signpost, 'Isolated Shack', '<h1>Isolated Shack</h1>Small hut constructed by a famous sculptor who, having garnered every laurel possible for his trade, abandoned his Koviri residence and moved here in order to find inspiration in solitude and reflect on what to make of the rest of his life'),
-			createMarker([-28.27, -103.97], icons.signpost, 'Blackbough', '<h1>Blackbough</h1>This village takes its name from the unwanted limbs loggers used to bring here to burn, leaving stacks of charred logs behind. The locals, however, prefer the old legend which holds that their village was founded by a prominent member of an ancient race of tree people'),
-			createMarker([-32.44, -123.05], icons.signpost, 'Hangman\'s Alley', '<h1>Hangman\'s Alley</h1>The road is lined with the hanged bodies of peasants who opposed their new rulers or had the bad luck of happening across bandits who had nothing against adding another dangling installation to the boulevard\'s scenery'),
-			createMarker([-39.71, -74.62], icons.signpost, 'Crow\'s Perch', '<h1>Crow\'s Perch</h1>After Vserad, its previous owner, panicked at the news that armies were approaching and fled to Fyke Isle, this castle became home to Phillip Strenger, alias the Bloody Baron, along with his family and entourage'),
-			createMarker([-52.81, -55.63], icons.signpost, 'Boatmakers\' Hut', '<h1>Boatmakers\' Hut</h1>Though nothing about this small domicile is particularly eye-catching, a family of the best shipwrights in Velen has lived here for generations, crafting the finest skiffs and dinghies north of the Yaruga'),
-			createMarker([-50.35, -140.98], icons.signpost, 'Regugees\' Camp', '<h1>Regugees\' Camp</h1>The members of this small community have erected a large, winged statue - evidence of people turning to old gods and ancient cults in this time of war and famine'),
-			createMarker([-45.01, -140.36], icons.signpost, 'Coast of Wrecks', '<h1>Coast of Wrecks</h1>Once the local youth would come here to revel amidst the wrecks. Now inhabitants of nearby villages have started combing the place day and night in search of anything that can be exchanged for food'),
-			createMarker([-53.67, -119.50], icons.signpost, 'Midcopse', '<h1>Midcopse</h1>Typical farming settlement which the worst of the fighting has left untouched - but which famine now grips all the same. One of the larger villages in this region'),
-			createMarker([-57.30, -98.57], icons.signpost, 'Wastrel Manor', '<h1>Wastrel Manor</h1>The once-beautiful manor house located near here was known for its extravagant balls, which were attended by the cream of the local youth. Its owners abandoned it over a century ago, but soon afterwards it became a place of worship for the local community, which believes a deity dwells in the ruins'),
-			createMarker([-62.01, -34.94], icons.signpost, 'Bandit\'s Camp', '<h1>Bandits\' Camp</h1>A place some particularly nasty characters have decided to call home'),
-			createMarker([-63.55, -74.44], icons.signpost, 'Oreton', '<h1>Oreton</h1>Village founded by Count Primislavus don Stessa, distant cousin to King Foltest of Temeria. The count was known for his passion for racing chariots down winding forest paths and narrow country roads. This spectacle delighted onlookers, won the hearts of the highborn ladies and aroused hatred in his rivals'),
-			createMarker([-45.68, -127.05], icons.signpost, 'Forest Hut', '<h1>Forest Hut</h1>Though his friends advised against building a house in the middle of the woods, Hans refused to listen and did things his way. When the war broke out and laid waste to this region, Hans and his family lived in peace, untouched by the troubles of the wider world - until one fateful night...'),
-			createMarker([-13.67, -84.20], icons.signpost, 'Wolven Glade', '<h1>Wolven Glade</h1>A long, long time ago, when this land was ruled by forest spirits and ancient gods, the living would come here to pay their respects to the dead in the way their holy tome comanded: "Walk thee in darkness, on a path of blood, standing under bare sky, naked before the gods and their messengers."'),
-			createMarker([-28.84, -60.56], icons.signpost, 'Burned Ruins', '<h1>Burned Ruins</h1>One of many structures in the area which did not survive the onslaught of war'),
-			createMarker([-47.10, -92.64], icons.signpost, 'Troll Bridge', '<h1>Troll Bridge</h1>Local legend has it this bridge was erected by trolls who were later killed by an anonymous witcher'),
-			createMarker([-53.96, -80.86], icons.signpost, 'Claywich', '<h1>Claywich</h1>Every year at Belleteyn, a great feast is held in Claywich accompanied by games, song and dance. On that night villagers from far and wide come to celebrate, with passing travelers welcome as well. Shortly before midnight the youth in attendance race deep into the forest in search of a fern flower, and though no one has as yet found one, many have found their other halves, or at least a night of moonlight passion'),
-			createMarker([-69.33, -39.59], icons.signpost, 'Drudge', '<h1>Drudge</h1>This once-peaceful fishermen\'s settlement now stands almost completely empty. Road-weary travelers sometimes find shelter in its abandoned huts - besides that, not a soul is to be seen'),
-		// SW Velen
-			createMarker([-64.09, -147.83], icons.signpost, 'Condyle', '<h1>Condyle</h1>This village has been completely and utterly destroyed. Rumors claim its inhabitants perished in a gruesome massacre'),
-			createMarker([-65.73, -128.41], icons.signpost, 'Duen Hen', '<h1>Duen Hen</h1>Religious site where the old gods are worshipped'),
-			createMarker([-73.30, -69.92], icons.signpost, 'Fyke Isle', '<h1>Fyke Isle</h1>Ruined tower which is said to be afflicted by a terrible curse'),
-			createMarker([-77.12, -112.72], icons.signpost, 'Byways', '<h1>Byways</h1>Most of this area\'s residents have fled north or died of plague. In better times they busied themselves making prize-winning bricks'),
-			createMarker([-80.79, -69.83], icons.signpost, 'Frischlow', '<h1>Frischlow</h1>Like many other settlements in the area, this one has suffered greatly on account of the war. Its inhabitants have abandoned their property and evacuated lands in which they once dwelled in relative peace'),
-			createMarker([-78.73, -41.44], icons.signpost, 'Olena\'s Grove', '<h1>Olena\'s Grove</h1>Legends claim that a beautiful nymph named Olena once lived in this grove. She fell in love with a young hunter and the man swore to be true to the nymph, but later betrayed her. She decided to punish him by casting a spell on his spirit, which wanders the grove to this day'),
-		// SE Velen
-			createMarker([-79.15, -10.28], icons.signpost, 'Road to Bald Mountain', '<h1>Road to Bald Mountain</h1>The peasants of Velen believe the summit of Bald Mountain is home to witches, werebbubbs and wights'),
-			createMarker([-80.90, 30.32], icons.signpost, 'Destroyed Bastion', '<h1>Destroyed Bastion</h1>Bastion built during the reign of King Gardic and destroyed during the First Nilfgaardian War'),
-			createMarker([-76.49, 41.62], icons.signpost, 'Crossroads', '<h1>Crossroads</h1>A small crossroads, well trodden by the inhabitants of the surrounding villages'),
-			createMarker([-77.56, 110.92], icons.signpost, 'Nilfgaardian Army Group \'Center\' Camp', '<h1>Nilfgaardian Army Group \'Center\' Camp</h1>Pitched in a mere two weeks, the Army Group \'Center\' camp constitutes the quintessence of Nilfgaardian martial architecture'),
-			createMarker([-74.73, 98.61], icons.signpost, 'House of Respite', '<h1>House of Respite</h1>The House of Respite\'s motto: "A soldier does not live on war alone." This is slightly misleading, however, for the club is not open to all soldiers, only Nilfgaardian officers (or those capable of passing themselves off as such)'),
-			createMarker([-69.16, 82.13], icons.signpost, 'Kimbolt Way', '<h1>Kimbolt Way</h1>Road built on orders of Baron Kimbolt, meant to act as a safe escape route in case his plans to take power after King Foltest\'s death went awry'),
-			createMarker([-67.09, 22.19], icons.signpost, 'The Orphans of Crookback Bog', '<h1>The Orphans of Crookback Bog</h1>Orphaned and unwanted children from nearby villages find a roof over their head and a bowl of warm food here'),
-			createMarker([-65.05, 37.53], icons.signpost, 'Ruined Tower', '<h1>Ruined Tower</h1>Five centuries ago King Geddes sent his most loyal knight, Martin of Oakdale, to watch over the inhabitants of this troubled land. He also sent his least-loyal knight, to scrub Martin\'s latrines'),
-			createMarker([-70.73, 43.68], icons.signpost, 'Ancient Oak', '<h1>Ancient Oak</h1>Centuries ago bloody rituals in honor of the old gods were conducted here. Locals believe dark forces still haunt this place'),
-			createMarker([-58.79, 30.63], icons.signpost, 'Downwarren', '<h1>Downwarren</h1>Before the war, the inhabitants of this village were known for their intricate lacemaking and artisanal smithery'),
-			createMarker([-54.39, 10.99], icons.signpost, 'Dragonslayer\'s Grotto', '<h1>Dragonslayer\'s Grotto</h1>Underneath this fortress lies a musty, rank cave in which a lost traveler will find nothing but a few fattened leeches - if he\'s lucky. Nevertheless, village elders insist on repeating the legend that gave the grotto its name: that of a legendary dragonslayer said to be buried somewhere deep inside'),
-			createMarker([-48.75, 30.72], icons.signpost, 'Reardon Manor', '<h1>Reardon Manor</h1>Abandoned estate of the once prominent Reardon family, relatives to the royal La Louve dynasty'),
-			createMarker([-50.63, 67.32], icons.signpost, 'Benek', '<h1>Benek</h1>This small village owes its name to its founding elder, who erected the largest windmill the land had ever seen on this spot - thereby providing work for all the village\'s inhabitants'),
-			createMarker([-36.10, 51.68], icons.signpost, 'Toderas', '<h1>Toderas</h1>Village founded by King Griffin of Temeria, the husband of Clarissa of Toussaint. The king had planned to turn Toderas into a large, bustling university city, a sort of Temerian alternative to Oxenfurt, but, as any visitor can quickly attest, his efforts failed utterly'),
-			createMarker([-34.42, 11.69], icons.signpost, 'Lurtch', '<h1>Lurtch</h1>Once the Evves family estate was located here and the area bore the name of Lord Evves\' wife, Mortilanca. When the couple died, their will stipulated their land be turned over to their serfs. The grateful peasants then founded a village of freeholders and named it after their first ealdorman, Lurtch, who had previously served as the Evves family\'s butler'),
-			createMarker([-36.81, -25.97], icons.signpost, 'Lindenvale', '<h1>Lindenvale</h1>One of Velen\'s many impoverished villages, its poverty deepened by war levies and the epidemic that spread after the Nilfgaardians\' arrival'),
-			createMarker([-17.22, 40.17], icons.signpost, 'Marauders\' Bridge', '<h1>Marauders\' Bridge</h1>After the Battle of Velen, marauders swarmed over this bridge in their rush to scavenge the battlefield'),
-			createMarker([-22.92, 71.59], icons.signpost, 'Grotto', '<h1>Grotto</h1>A dark and hostile place which creaks from time to time with unsettling, throaty noises...'),
-	]);
+		signpost: [{ // Novigrad
+			coords: [[73.76, -33.97]],
+			label: 'Hierarch Square',
+			popup: 'Until quite recently a great many mages lived near Novigrad\'s main square. They fled when the witch hunters began their reign of terror, leaving many of the city\'s most beautiful townhouses abandoned and uncared for'
+		}, {
+			coords: [[74.23, -15.86]],
+			label: 'Southern Gate',
+			popup: 'In truth demarcating the eastern and not southern edge of the city, the Southern Gate was given its inappropriate name by a one-time city planner who knew nothing about architecture and could not read a map, but had in his favor the fact that he was the mayor\'s cousin and thew lavish parties. Though confusingly incorrect, the name stuck and now the city\'s residents never think twice about its illogical appellation'
+		}, {
+			coords: [[76.44, -16.20]],
+			label: 'Oxenfurt Gate',
+			popup: 'In the times when Novigrad and Oxenfurt were embroiled in fierce neighborly disputes, this gate went through several completely different names, the Gate of Harlots and the Gate of Bloodsuckers being two of the longer lived examples. Its current name was chosen when this conflict was finally put to rest'
+		}, {
+			coords: [[77.64, -36.47]],
+			label: 'St. Gregory\'s Bridge',
+			popup: 'Bridge named after the hero of Novigrad who saved the city from a horrible famine three hundred years ago by sacrificing half his fortune to import food from Nazair. After this, he was declared a saint, something even the jurors of the Church of the Eternal Fire were unable to change'
+		}, {
+			coords: [[79.73, -51.24]],
+			label: 'Electors\' Square',
+			popup: 'Square named after a group of Novigrad reformers who enacted bold transformations that led to the city\'s rapid growth, enriching its residents considerably and ushering in the city\'s golden age'
+		}, {
+			coords: [[71.16, -22.94]],
+			label: 'Tretogor Gate',
+			popup: 'Gate erected with funds from the Redanian royal family, who, wanting to earn favor with Novigrad merchants and the hierach, dedicated a significant amount of coin to its construction, as well as some no-less-valuable (wo)manpower in the form of the master architect Countess Anna Yaye-Pinkovitz and her skilled crew'
+		}, {
+			coords: [[68.94, -27.77]],
+			label: 'Gate of the Hierarch',
+			popup: 'This gate is named in honor of Novigrad\'s own son, the Hierach of the eternal Fire. Supposedly this name was given to it upon popular request, though no one can be found who remembers requesting any such thing'
+		}, {
+			coords: [[66.32, -35.31]],
+			label: 'Glory Gate',
+			popup: 'Toughs and hooligans often end a night of drunken escapades under this gate after being thrown out of the nearby taverns'
+		}, {
+			coords: [[65.99, -43.90]],
+			label: 'Portside Gate',
+			popup: 'Though not the most stately of gates, this one\'s location near the bustling port has made it the calling card of the city'
+		}, {
+			coords: [[69.57, -55.28]],
+			label: 'Novigrad Docks',
+			popup: 'A den of dirt and depravity and the shadiest part of Novigrad. After dark all one finds here are women of loose morals, hoodlums and drunk sailors'
+		}, {
+			coords: [[75.39, -8.88]],
+			label: 'Arette',
+			popup: 'Novigrad has always attracted those in search of a better life. Some of them found no welcome within the city walls, and so built huts outside the city'
+		}, {
+			coords: [[69.57, -2.81]],
+			label: 'Seven Cats Inn',
+			popup: 'This dank establishment is host to a shady clientele'
+		}, { // NE Novigrad
+			coords: [[83.53, -9.40]],
+			label: 'Sarrasin Grange',
+			popup: 'Lord Antares Sarrasin moved his wife and smattering of comely daughters here from far-off Nazair on his medic\'s recommendations. The leech proclaimed with absolute certainy that "if you wish to sire a son, it must be in the Gustfields." While waiting to produce a male heir, the Sarrasins took to wine cultivation and soon their grange became renowned from Nazair to Skellige'
+		}, {
+			coords: [[81.92, 3.60]],
+			label: 'Yantra',
+			popup: 'The inhabitants of this village are known for their talkativeness and tendency to exagerrate, which makes them good companions for a round of drink, but impossible to tolerate for long stretches of time'
+		}, {
+			coords: [[82.09, 30.15]],
+			label: 'Isolated Hut',
+			popup: 'Rumors claim a famous painter lives in this house, though no one has ever seen him or knows his name'
+		}, {
+			coords: [[76.24, 18.26]],
+			label: 'Honeyfill Meadworks',
+			popup: 'The renowned Honeyfill Meadworks has for generations belonged to a respected family of halflings'
+		}, {
+			coords: [[79.04, 65.21]],
+			label: 'Martin Feuille\'s Farmstead',
+			popup: 'Founded by Lord Martin Feuille, this vast plantation was until not so long ago the largest producer of alfalfa in the region. Sadly, when war broke out the lord fled to his winter residence in Kovir, leaving his land to be administered by an ill-suited stward who squandered his liege\'s fertile fields'
+		}, {
+			coords: [[81.02, 49.09]],
+			label: 'Winespring Grange',
+			popup: 'Years ago, an eccentric count named Jacobus Ruth of the Rieslings settled here. The count could not stand the pomposity of court life but loved good wine. He thus planted a vineyard here which produces a fabulous beaujolais prized on both sides of the Pontar'
+		}, {
+			coords: [[79.59, 31.03]],
+			label: 'Moldavie Residence',
+			popup: 'Despite its ideal location and beautiful surroundings, this residence has been tossed from owner to owner like a hot potato, and for some unknown reason suffers from a bad reputation'
+		}, {
+			coords: [[81.66, -31.55]],
+			label: 'Cavern',
+			popup: 'One of those places wise men avoid at all costs, so as not to tempt fate'
+		}, { // E Novigrad
+			coords: [[72.92, 41.31]],
+			label: 'Alness',
+			popup: 'Until recently, this was a thoroughly unremarkable village. then the Vegelbuds began organizing their famous horse races here, granting Alness the enviable honor of hosting the region\'s most pretigious equestrian contests'
+		}, {
+			coords: [[67.58, 31.03]],
+			label: 'Wheat Fields',
+			popup: 'The fertile soils of the Pontar delta guarantee the inhabitants of Novigrad full granaries and full stomaches all year long'
+		}, {
+			coords: [[65.31, 46.67]],
+			label: 'Vegelbud Residence',
+			popup: 'Domicile of a prominent Novigrad family whose line can be traced back to the times when the first human settlers came to these lands'
+		}, { // SE Novigrad
+			coords: [[62.02, 39.11]],
+			label: 'Carsten',
+			popup: 'A village named after a baker whose exquisite goods gained him fame, as well as the privilege of supplying bread to the table of the hierarch of the Church of the Eternal Fire in Novigrad. Following his death, none proved capable of recreating his recipes for his delicious and depply aromatic breads, so these days Carsten is known chiefly for its trade in grain and flour'
+		}, {
+			coords: [[58.56, 66.27]],
+			label: 'Temerian Partisan Hideout',
+			popup: 'Though the Nilfgaardians thought Temeria died along with King Foltest, Temerian guerillas still hide in the woods, prepared to give their lives at a moment\'s notice in their fight for independence'
+		}, {
+			coords: [[59.82, 85.87]],
+			label: 'Est Tayiar',
+			popup: 'Long before men first peopled these lands, a beautiful, prospering elven city stood here, centered around the palace of King Maeglor. One day, however, the city\'s inhabitants began mysteriously dying off in large numbers. According to legend, King Maeglor sensed he, too, would soon perish and cast a powerful spell that caused the earth to swallow the city whole so that no outsider could ever desecrate it. Centuries later, scholars from the Oxenfurt Academy began painstaking excavations of King Maeglor\'s palace in a search for the causes of the catastrophe. Yet work came to a sudden halt when three subsequent expeditions ventured into the ruins\' depths - and were never heard from again...'
+		}, {
+			coords: [[49.45, 70.67]],
+			label: 'Herbalist\'s Hut',
+			popup: 'Home to a halfling herbalist who is a passionate devotee of innovative gardening methods and experimental herbal medicine'
+		}, {
+			coords: [[35.51, 110.67]],
+			label: 'Aeramas\' Abandoned Manor',
+			popup: 'Peasants living nearby often complain about the overwhelming cheese stench wafting out of this residence...'
+		}, {
+			coords: [[19.89, 83.06]],
+			label: 'Crossroads',
+			popup: 'A small crossroads in the woods'
+		}, {
+			coords: [[49.85, 52.73]],
+			label: 'Gustfields Farm',
+			popup: 'Farmstead founded years ago by an eccentric flaxen-haired painter named Cunigund de Cabbrae, who came here seeking peace, quiet and fresh country air'
+		}, {
+			coords: [[76.64, 37.00]],
+			label: 'Dancing Windmill',
+			popup: 'When the current owner\'s grandfather, the famous dancer Pablo "Sugar" Sasko, ended his career, he settled here and organised nights of dancing for the nearby peasantry. Supposedly these revelries became so fashionable that dung-booted peasants were dancing rounds with members of Novigrad\'s most elite familes and adventure-seeking urban dandies'
+		}, { // S Novigrad
+			coords: [[67.20, -65.48]],
+			label: 'Loggers Hut',
+			popup: 'A lone cabin deep in the Novigrad Forest - an ideal base for woodcutters'
+		}, {
+			coords: [[66.92, -85.25]],
+			label: 'Lighthouse',
+			popup: 'Many years ago a horrible accident took place here: a ship carrying the cousin of King Radovid IV the Bald wrecked against the rocks during a storm. The king ordered a lighthouse erected on that spot in order to warn other seafarers of its deadly danger'
+		}, {
+			coords: [[61.90, -14.08]],
+			label: 'Cunny of the Goose',
+			popup: 'This inn owes its name to its former owner, a swaggering, blustering fellow who wanted to attract those of a similar temperatment. Luckily he died of liver poisoning after a few years and ownership passed to a distant relative, who turned the Cunny of the Goose into the best spot for stuffed goose liver in all the region'
+		}, {
+			coords: [[58.03, -29.44]],
+			label: 'Drahim Castle',
+			popup: 'In its glory years, this castle was home to the Redanian Moskovitz of the Sea Cats dynasty, patrons of the arts and admirers of elven culture. After the death by suicide of the dynasty\'s last member, Prince Adrien, the castle fell into the hands of the Redanian crown - and then into ruin'
+		}, {
+			coords: [[54.10, -71.98]],
+			label: 'Widows\' Grotto',
+			popup: 'According to legend, many years ago a young woman would wait here and watch for her husband\'s return from an overseas raid. Years passed and the woman grew old, still waiting for her husband. Yet he never came, and finally, she died. Three days after her funeral, her husband returned, having at last escaped from the pirates who had held him captive all that time. When he learned about his beloved\'s loyal vigil, he wept bitter tears, then lept to his death'
+		}, {
+			coords: [[45.98, -51.33]],
+			label: 'Ursten',
+			popup: 'War has caused countless refugees to flee Temeria. With the Pontar blockaded, they have tended to flood villages which, like Ursten, are located close to river crossings'
+		}, {
+			coords: [[60.50, -55.55]],
+			label: 'Lucian\'s Windmill',
+			popup: 'Lucian le Foix, the famous Oxenfurt sculptor and architect, bought this windmill several years ago and made it into his country retreat. Sadly the enormous popularity of the great Lucian\'s designs means he spends little time in his fortress of solitude and has entrusted its care to a steward'
+		}, {
+			coords: [[62.35, 11.69]],
+			label: 'Eternal Fire Chapel',
+			popup: 'This shrine greets travelers on their way to Oxenfurt. Merchants sometimes stop here to sell goods to pilgrims and visiting scholars'
+		}, {
+			coords: [[37.11, -27.23]],
+			label: 'Border Post',
+			popup: 'A small isle stuck in the river\'s central current - an ideal place for bleaching cloth'
+		}, { // Oxenfurt
+			coords: [[38.17, 62.31]],
+			label: 'Novigrad Gate',
+			popup: 'During Oxenfurt Academy\'s exam sessions, this gate would be closed, to spare the students from Novigrad\'s temptations'
+		}, {
+			coords: [[29.10, 52.58]],
+			label: 'Western Gate',
+			popup: 'Before war broke out, several hundred people a day would pass through here. Now the Redanian blockade has slowed traffic to a mere trickle'
+		}, {
+			coords: [[37.40, 48.34]],
+			label: 'Oxenfurt Harbor',
+			popup: 'Oxenfurt\'s picturesque port has featured as the subject of numerous odes and ballads, the setting for at least three lurid crime novels, and a favorite spot for romantic outings for generations of students'
+		}, { // NE Velen
+			coords: [[15.62, 25.66]],
+			label: 'Stonecutters\' Settlement',
+			popup: 'Over Twenty years ago a certain Bartolomeo, known as "Badger" on account of certain characteristic aspects of his coiffure, discovered a rich deposit of high-quality stone on this spot. He bought the land for a song, then leased it back to local peasants before heading off to Kovir, where he lives the life of a rich and powerful townsman to this day'
+		}, {
+			coords: [[35.96, 34.41]],
+			label: 'White Eagle Fort',
+			popup: 'The grand name might seem in ill-fitting with this place, but the troll that lives here - a Redanian patriot and military aficionado - goes to great lengths to make his beloved King Radovid proud'
+		}, {
+			coords: [[27.45, 12.00]],
+			label: 'Codgers\' Quarry',
+			popup: 'The now-inactive quarry once only employed stonebreakers over thirty years of age who would work hard all day, then spend the evenings racing down the sides of the quarry pit on hand-crafted wagons'
+		}, {
+			coords: [[39.61, -2.42]],
+			label: 'Hindhold',
+			popup: 'This watchtower used to protect barges traveling between Oxenfurt and Novigrad. It once even boasted a bridge connecting the two sides of the river, but now it stands abandoned and neglected, its bridge a collapsed ruin'
+		}, {
+			coords: [[-4.01, 63.37]],
+			label: 'Ferry Station',
+			popup: 'The ferry\'s former owners were famed for treating travelers who were forced to wait for better conditions to raucous and unforgettable evenings'
+		}, {
+			coords: [[13.75, -9.05]],
+			label: 'Hanged Man\'s Tree',
+			popup: 'During the war, both sides committed acts of exorbitant cruelty meant to keep the conquered populaces in check'
+		}, {
+			coords: [[5.22, 5.41]],
+			label: 'Devil\'s Pit',
+			popup: 'The inhabitants of Velen believe the expanse of caverns underneath the Devil\'s Pit are home to demons'
+		}, {
+			coords: [[1.43, -15.16]],
+			label: 'Mulbrydale',
+			popup: 'One of the oldest villages in the region. Owes its name to a certain undereducated botanist who could not discern one kind of tree from another and so called them all mulberries'
+		}, {
+			coords: [[0.82, -47.20]],
+			label: 'Inn at the Crossroads',
+			popup: 'A sizeable establishment able to accommodate a crowd of travelers and revelers'
+		}, { // NW Velen
+			coords: [[21.78, -106.54]],
+			label: 'Harpy Feeding Ground',
+			popup: 'One of those places entered by only the very brave, or very foolish'
+		}, {
+			coords: [[30.56, -114.31]],
+			label: 'Lornruk',
+			popup: 'Years ago smugglers would come here to load and unload illicit cargo'
+		}, {
+			coords: [[-1.85, -98.61]],
+			label: 'Heatherton',
+			popup: 'The inhabitants of this village were relieved when they learned the path of the marching armies had shifted slightly and passed their village bye. Then, one night... they changed their mind'
+		}, {
+			coords: [[0.97, -110.39]],
+			label: 'Abandoned Tower',
+			popup: 'Legend has it a beleaguered traveler once stood at this tower\'s gates. He begged for shelter for the night, claiming he\'d been injured, but the baron living inside was afraid the traveler was a spy and sent him away. Little did he know the traveler was a powerful mage, who cast a curse on the tower, its inhospitable owner and all who dwelled with him. Soon thereafter the baron and all his retinue died in mysterious circumstances, and the tower fell into ruin'
+		}, {
+			coords: [[2.37, -122.34]],
+			label: 'Isolated Shack',
+			popup: 'Small hut constructed by a famous sculptor who, having garnered every laurel possible for his trade, abandoned his Koviri residence and moved here in order to find inspiration in solitude and reflect on what to make of the rest of his life'
+		}, {
+			coords: [[-28.27, -103.97]],
+			label: 'Blackbough',
+			popup: 'This village takes its name from the unwanted limbs loggers used to bring here to burn, leaving stacks of charred logs behind. The locals, however, prefer the old legend which holds that their village was founded by a prominent member of an ancient race of tree people'
+		}, {
+			coords: [[-32.44, -123.05]],
+			label: 'Hangman\'s Alley',
+			popup: 'The road is lined with the hanged bodies of peasants who opposed their new rulers or had the bad luck of happening across bandits who had nothing against adding another dangling installation to the boulevard\'s scenery'
+		}, {
+			coords: [[-39.71, -74.62]],
+			label: 'Crow\'s Perch',
+			popup: 'After Vserad, its previous owner, panicked at the news that armies were approaching and fled to Fyke Isle, this castle became home to Phillip Strenger, alias the Bloody Baron, along with his family and entourage'
+		}, {
+			coords: [[-52.81, -55.63]],
+			label: 'Boatmakers\' Hut',
+			popup: 'Though nothing about this small domicile is particularly eye-catching, a family of the best shipwrights in Velen has lived here for generations, crafting the finest skiffs and dinghies north of the Yaruga'
+		}, {
+			coords: [[-50.35, -140.98]],
+			label: 'Regugees\' Camp',
+			popup: 'The members of this small community have erected a large, winged statue - evidence of people turning to old gods and ancient cults in this time of war and famine'
+		}, {
+			coords: [[-45.01, -140.36]],
+			label: 'Coast of Wrecks',
+			popup: 'Once the local youth would come here to revel amidst the wrecks. Now inhabitants of nearby villages have started combing the place day and night in search of anything that can be exchanged for food'
+		}, {
+			coords: [[-53.67, -119.50]],
+			label: 'Midcopse',
+			popup: 'Typical farming settlement which the worst of the fighting has left untouched - but which famine now grips all the same. One of the larger villages in this region'
+		}, {
+			coords: [[-57.30, -98.57]],
+			label: 'Wastrel Manor',
+			popup: 'The once-beautiful manor house located near here was known for its extravagant balls, which were attended by the cream of the local youth. Its owners abandoned it over a century ago, but soon afterwards it became a place of worship for the local community, which believes a deity dwells in the ruins'
+		}, {
+			coords: [[-62.01, -34.94]],
+			label: "Bandits' Camp",
+			popup: 'A place some particularly nasty characters have decided to call home'
+		}, {
+			coords: [[-63.55, -74.44]],
+			label: 'Oreton',
+			popup: 'Village founded by Count Primislavus don Stessa, distant cousin to King Foltest of Temeria. The count was known for his passion for racing chariots down winding forest paths and narrow country roads. This spectacle delighted onlookers, won the hearts of the highborn ladies and aroused hatred in his rivals'
+		}, {
+			coords: [[-45.68, -127.05]],
+			label: 'Forest Hut',
+			popup: 'Though his friends advised against building a house in the middle of the woods, Hans refused to listen and did things his way. When the war broke out and laid waste to this region, Hans and his family lived in peace, untouched by the troubles of the wider world - until one fateful night...'
+		}, {
+			coords: [[-13.67, -84.20]],
+			label: 'Wolven Glade',
+			popup: 'A long, long time ago, when this land was ruled by forest spirits and ancient gods, the living would come here to pay their respects to the dead in the way their holy tome comanded: "Walk thee in darkness, on a path of blood, standing under bare sky, naked before the gods and their messengers."'
+		}, {
+			coords: [[-28.84, -60.56]],
+			label: 'Burned Ruins',
+			popup: 'One of many structures in the area which did not survive the onslaught of war'
+		}, {
+			coords: [[-47.10, -92.64]],
+			label: 'Troll Bridge',
+			popup: 'Local legend has it this bridge was erected by trolls who were later killed by an anonymous witcher'
+		}, {
+			coords: [[-53.96, -80.86]],
+			label: 'Claywich',
+			popup: 'Every year at Belleteyn, a great feast is held in Claywich accompanied by games, song and dance. On that night villagers from far and wide come to celebrate, with passing travelers welcome as well. Shortly before midnight the youth in attendance race deep into the forest in search of a fern flower, and though no one has as yet found one, many have found their other halves, or at least a night of moonlight passion'
+		}, {
+			coords: [[-69.33, -39.59]],
+			label: 'Drudge',
+			popup: 'This once-peaceful fishermen\'s settlement now stands almost completely empty. Road-weary travelers sometimes find shelter in its abandoned huts - besides that, not a soul is to be seen'
+		}, { // SW Velen
+			coords: [[-64.09, -147.83]],
+			label: 'Condyle',
+			popup: 'This village has been completely and utterly destroyed. Rumors claim its inhabitants perished in a gruesome massacre'
+		}, {
+			coords: [[-65.73, -128.41]],
+			label: 'Duen Hen',
+			popup: 'Religious site where the old gods are worshipped'
+		}, {
+			coords: [[-73.30, -69.92]],
+			label: 'Fyke Isle',
+			popup: 'Ruined tower which is said to be afflicted by a terrible curse'
+		}, {
+			coords: [[-77.12, -112.72]],
+			label: 'Byways',
+			popup: 'Most of this area\'s residents have fled north or died of plague. In better times they busied themselves making prize-winning bricks'
+		}, {
+			coords: [[-80.79, -69.83]],
+			label: 'Frischlow',
+			popup: 'Like many other settlements in the area, this one has suffered greatly on account of the war. Its inhabitants have abandoned their property and evacuated lands in which they once dwelled in relative peace'
+		}, {
+			coords: [[-78.73, -41.44]],
+			label: 'Olena\'s Grove',
+			popup: 'Legends claim that a beautiful nymph named Olena once lived in this grove. She fell in love with a young hunter and the man swore to be true to the nymph, but later betrayed her. She decided to punish him by casting a spell on his spirit, which wanders the grove to this day'
+		}, { // SE Velen
+			coords: [[-79.15, -10.28]],
+			label: 'Road to Bald Mountain',
+			popup: 'The peasants of Velen believe the summit of Bald Mountain is home to witches, werebbubbs and wights'
+		}, {
+			coords: [[-80.90, 30.32]],
+			label: 'Destroyed Bastion',
+			popup: 'Bastion built during the reign of King Gardic and destroyed during the First Nilfgaardian War'
+		}, {
+			coords: [[-76.49, 41.62]],
+			label: 'Crossroads',
+			popup: 'A small crossroads, well trodden by the inhabitants of the surrounding villages'
+		}, {
+			coords: [[-77.56, 110.92]],
+			label: 'Nilfgaardian Army Group \'Center\' Camp',
+			popup: 'Pitched in a mere two weeks, the Army Group \'Center\' camp constitutes the quintessence of Nilfgaardian martial architecture'
+		}, {
+			coords: [[-74.73, 98.61]],
+			label: 'House of Respite',
+			popup: 'The House of Respite\'s motto: "A soldier does not live on war alone." This is slightly misleading, however, for the club is not open to all soldiers, only Nilfgaardian officers (or those capable of passing themselves off as such)'
+		}, {
+			coords: [[-69.16, 82.13]],
+			label: 'Kimbolt Way',
+			popup: 'Road built on orders of Baron Kimbolt, meant to act as a safe escape route in case his plans to take power after King Foltest\'s death went awry'
+		}, {
+			coords: [[-67.09, 22.19]],
+			label: 'The Orphans of Crookback Bog',
+			popup: 'Orphaned and unwanted children from nearby villages find a roof over their head and a bowl of warm food here'
+		}, {
+			coords: [[-65.05, 37.53]],
+			label: 'Ruined Tower',
+			popup: 'Five centuries ago King Geddes sent his most loyal knight, Martin of Oakdale, to watch over the inhabitants of this troubled land. He also sent his least-loyal knight, to scrub Martin\'s latrines'
+		}, {
+			coords: [[-70.73, 43.68]],
+			label: 'Ancient Oak',
+			popup: 'Centuries ago bloody rituals in honor of the old gods were conducted here. Locals believe dark forces still haunt this place'
+		}, {
+			coords: [[-58.79, 30.63]],
+			label: 'Downwarren',
+			popup: 'Before the war, the inhabitants of this village were known for their intricate lacemaking and artisanal smithery'
+		}, {
+			coords: [[-54.39, 10.99]],
+			label: 'Dragonslayer\'s Grotto',
+			popup: 'Underneath this fortress lies a musty, rank cave in which a lost traveler will find nothing but a few fattened leeches - if he\'s lucky. Nevertheless, village elders insist on repeating the legend that gave the grotto its name: that of a legendary dragonslayer said to be buried somewhere deep inside'
+		}, {
+			coords: [[-48.75, 30.72]],
+			label: 'Reardon Manor',
+			popup: 'Abandoned estate of the once prominent Reardon family, relatives to the royal La Louve dynasty'
+		}, {
+			coords: [[-50.63, 67.32]],
+			label: 'Benek',
+			popup: 'This small village owes its name to its founding elder, who erected the largest windmill the land had ever seen on this spot - thereby providing work for all the village\'s inhabitants'
+		}, {
+			coords: [[-36.10, 51.68]],
+			label: 'Toderas',
+			popup: 'Village founded by King Griffin of Temeria, the husband of Clarissa of Toussaint. The king had planned to turn Toderas into a large, bustling university city, a sort of Temerian alternative to Oxenfurt, but, as any visitor can quickly attest, his efforts failed utterly'
+		}, {
+			coords: [[-34.42, 11.69]],
+			label: 'Lurtch',
+			popup: 'Once the Evves family estate was located here and the area bore the name of Lord Evves\' wife, Mortilanca. When the couple died, their will stipulated their land be turned over to their serfs. The grateful peasants then founded a village of freeholders and named it after their first ealdorman, Lurtch, who had previously served as the Evves family\'s butler'
+		}, {
+			coords: [[-36.81, -25.97]],
+			label: 'Lindenvale',
+			popup: 'One of Velen\'s many impoverished villages, its poverty deepened by war levies and the epidemic that spread after the Nilfgaardians\' arrival'
+		}, {
+			coords: [[-17.22, 40.17]],
+			label: 'Marauders\' Bridge',
+			popup: 'After the Battle of Velen, marauders swarmed over this bridge in their rush to scavenge the battlefield'
+		}, {
+			coords: [[-22.92, 71.59]],
+			label: 'Grotto',
+			popup: 'A dark and hostile place which creaks from time to time with unsettling, throaty noises...'
+		}],
 
 	// Smugglers' Cache
-	var smugglersGeneric = genericMarkers([
-		// Novigrad
-			[67.37, -33.44],
-			[71.07, -9.14],
-		// S Novigrad
-			[61.17, -84.11],
-		// NW Velen
-			[-58.90, -158.82],
-	], icons.smugglers, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
+		smugglers: [{
+			coords: [
+				// Novigrad
+				[67.37, -33.44],
+				[71.07, -9.14],
+				// S Novigrad
+				[61.17, -84.11],
+				// NW Velen
+				[-58.90, -158.82],
+			],
+			label: "Smugglers' Cache",
+			popup: 'Smuggled goods have been hidden here'
+		}],
 
-	markers.smugglers = L.layerGroup($.merge(smugglersGeneric, [
-		// No custom markers needed
-	]));
 
 	// Spoils of War
-	markers.spoils = L.layerGroup([
-		// NE Velen
-			createMarker([33.91, -68.51], icons.spoils, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'),
-		// NW Velen
-			createMarker([-22.72, -32.04], icons.spoils, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish (lvl 4<span> Drowners</span>'),
-		// SW Velen
-			createMarker([-74.75, -144.93], icons.spoils, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish (lvl 10<span> Drowners</span>)'),
-	]);
+		spoils: [{ // NE Velen
+			coords: [[33.91, -68.51]],
+			label: 'Spoils of War',
+			popup: 'Search here for loot left behind after a battle or skirmish'
+		}, { // NW Velen
+			coords: [[-22.72, -32.04]],
+			label: 'Spoils of War',
+			popup: 'Search here for loot left behind after a battle or skirmish (lvl 4<span> Drowners</span>'
+		}, { // SW Velen
+			coords: [[-74.75, -144.93]],
+			label: 'Spoils of War',
+			popup: 'Search here for loot left behind after a battle or skirmish (lvl 10<span> Drowners</span>)'
+		}]
+	});
+
 
 	window.allLayers = [
 		markers.abandoned,

--- a/files/js/mapdata-velen.js
+++ b/files/js/mapdata-velen.js
@@ -1,10 +1,11 @@
-$(function()
-{
-	map_path   = 'velen';
-	map_sWest  = L.latLng(-85.05, -180);
-	map_nEast  = L.latLng(85.05, 135);
-	map_center = [60, -5];
-	map_mZoom  = 6;
+$(function() {
+	window.map_path   = 'velen';
+	window.map_sWest  = L.latLng(-85.05, -180);
+	window.map_nEast  = L.latLng(85.05, 135);
+	window.map_center = [60, -5];
+	window.map_mZoom  = 6;
+
+	window.markers = {};
 
 	// Abandoned Site
 		var abandonedIcon = L.icon({
@@ -12,7 +13,7 @@ $(function()
 			iconSize : [30, 30]
 		});
 
-		abandonedGeneric = genericMarkers([
+		var abandonedGeneric = genericMarkers([
 			// NW Velen
 				[-53.59, -56.34],
 				[-29.34, -136.23],
@@ -20,7 +21,7 @@ $(function()
 				[-58.95, -142.21],
 		], abandonedIcon, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more');
 
-		abandonedMarkers = L.layerGroup($.merge(abandonedGeneric, [
+		window.markers['abandoned'] = L.layerGroup($.merge(abandonedGeneric, [
 			// NE Velen
 				L.marker([-17.06, 8.26], setMarker(abandonedIcon)).bindLabel('Abandoned Site').bindPopup('<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 4<span> Drowners</span>)'),
 				L.marker([13.70, 46.05], setMarker(abandonedIcon)).bindLabel('Abandoned Site').bindPopup('<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Drowners</span>)'),
@@ -38,7 +39,7 @@ $(function()
 			iconSize : [20, 28]
 		});
 
-		alchemyMarkers = L.layerGroup([
+		window.markers['alchemy'] = L.layerGroup([
 			// Novigrad
 				L.marker([77.71, -15.91], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies*').bindPopup('<h1>Alchemy Supplies*</h1>Here you can buy alchemy ingredients, also pays well trophies'),
 				L.marker([79.75, -49.83], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies').bindPopup('<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
@@ -52,7 +53,7 @@ $(function()
 			iconSize : [24, 34]
 		});
 
-		armourerMarkers = L.layerGroup([
+		window.markers['armourer'] = L.layerGroup([
 			// Novigrad
 				L.marker([74.23, -38.23], setMarker(armourerIcon)).bindLabel('Journeyman Armorer').bindPopup('<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
 			// Oxenfurt
@@ -71,7 +72,7 @@ $(function()
 			iconSize : [30, 27]
 		});
 
-		armourerstableMarkers = L.layerGroup(genericMarkers([
+		window.markers['armourerstable'] = L.layerGroup(genericMarkers([
 			// Novigrad
 				[75.27, -43.35],
 				[75.00, -40.68],
@@ -96,7 +97,7 @@ $(function()
 			iconSize : [29, 30]
 		});
 
-		banditcampGeneric = genericMarkers([
+		var banditcampGeneric = genericMarkers([
 			// NE Velen
 				[11.61, -54.42],
 			// NW Velen
@@ -114,7 +115,7 @@ $(function()
 				[-29.69, -17.23],
 		], banditcampIcon, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here');
 
-		banditcampMarkers = L.layerGroup($.merge(banditcampGeneric, [
+		window.markers['banditcamp'] = L.layerGroup($.merge(banditcampGeneric, [
 			// S Novigrad
 				L.marker([55.43, -63.00], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
 			// E Novigrad
@@ -139,7 +140,7 @@ $(function()
 			iconSize : [30, 30]
 		});
 
-		barberMarkers = L.layerGroup(genericMarkers([
+		window.markers['barber'] = L.layerGroup(genericMarkers([
 			// Novigrad
 				[76.45, -33.18],
 				[76.32, -20.39],
@@ -155,7 +156,7 @@ $(function()
 			iconSize : [27, 30]
 		});
 
-		blacksmithMarkers = L.layerGroup([
+		window.markers['blacksmith'] = L.layerGroup([
 			// Novigrad
 				L.marker([69.15, -41.00], setMarker(blacksmithIcon)).bindLabel('Master Blacksmith*').bindPopup('<h1>Master Blacksmith</h1>You must complete "Of Swords and Dumplings" (level 24) quest in order to unlock this blacksmith. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
 				L.marker([73.14, -37.96], setMarker(blacksmithIcon)).bindLabel('Journeyman Blacksmith').bindPopup('<h1>Journeyman Blacksmith</h1>This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
@@ -175,7 +176,7 @@ $(function()
 			iconSize : [28, 26]
 		});
 
-		brothelMarkers = L.layerGroup([
+		window.markers['brothel'] = L.layerGroup([
 			// Novigrad
 				L.marker([71.22, -41.84], setMarker(brothelIcon)).bindLabel('Crippled Kate').bindPopup('<h1>Crippled Kate Brothel</h1>You can call on the services of a prostitute here'),
 				L.marker([78.34, -33.40], setMarker(brothelIcon)).bindLabel('Passiflora').bindPopup('<h1>Passiflora Brothel</h1>You can call on the services of a prostitute here')
@@ -188,7 +189,7 @@ $(function()
 			iconSize : [30, 28]
 		});
 
-		boatMarkers = L.layerGroup(genericMarkers([
+		window.markers['boat'] = L.layerGroup(genericMarkers([
 			// Novigrad
 				[69.84, -13.01],
 				[72.82, -10.28],
@@ -255,7 +256,7 @@ $(function()
 		});
 
 		// todo, entrance to what?
-		entranceMarkers = L.layerGroup([
+		window.markers['entrance'] = L.layerGroup([
 			// Novigrad
 				L.marker([80.68, -55.02], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
 			// NE Novigrad
@@ -295,7 +296,7 @@ $(function()
 			iconSize : [30, 26]
 		});
 
-		grindstoneMarkers = L.layerGroup(genericMarkers([
+		window.markers['grindstone'] = L.layerGroup(genericMarkers([
 			// Novigrad
 				[75.27, -42.95],
 				[74.96, -40.28],
@@ -336,7 +337,7 @@ $(function()
 				[-51.78, -6.42],
 		], guardedIcon, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
 
-		guardedMarkers = L.layerGroup($.merge(guardedGeneric, [
+		window.markers['guarded'] = L.layerGroup($.merge(guardedGeneric, [
 			// NE Novigrad
 				L.marker([76.43, -2.07], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'),
 				L.marker([80.52, -4.53], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 15<span> Bilge Hag</span>) guards a valuable cache here'),
@@ -374,7 +375,7 @@ $(function()
 			iconSize : [24, 30]
 		});
 
-		gwentMarkers = L.layerGroup([
+		window.markers['gwent'] = L.layerGroup([
 			// Novigrad
 				L.marker([74.618, -35.132], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Book Merchant Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
 				L.marker([71.00, -41.90], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Crippled Kate Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
@@ -434,7 +435,7 @@ $(function()
 			iconSize : [27, 30]
 		});
 
-		harborMarkers = L.layerGroup(genericMarkers([
+		window.markers['harbor'] = L.layerGroup(genericMarkers([
 			// Novigrad
 				[70.64, -58.93],
 			// Oxenfurt
@@ -470,7 +471,7 @@ $(function()
 				[50.54, 72.07],
 		], herbalistIcon, 'Herbalist', '<h1>Herbalist</h1>Here you can buy alchemy ingredients');
 
-		herbalistMarkers = L.layerGroup($.merge(herbalistGeneric, [
+		window.markers['herbalist'] = L.layerGroup($.merge(herbalistGeneric, [
 			// NW Velen
 				L.marker([-50.26, -138.91], setMarker(herbalistIcon)).bindLabel('Herbalist').bindPopup('<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
 				L.marker([-28.15, -135.26], setMarker(herbalistIcon)).bindLabel('Herbalist').bindPopup('<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
@@ -499,7 +500,7 @@ $(function()
 				[-29.99, 28.39],
 		], hiddenIcon, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
 
-		hiddenMarkers = L.layerGroup($.merge(hiddenGeneric, [
+		window.markers['hidden'] = L.layerGroup($.merge(hiddenGeneric, [
 			// S Novigrad
 				L.marker([34.55, -43.68], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 6<span> Nekkers</span>)'),
 				L.marker([49.38, -68.91], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 15<span> Mucknixers</span>)'),
@@ -529,7 +530,7 @@ $(function()
 			iconSize : [26, 30]
 		});
 
-		innkeepMarkers = L.layerGroup([
+		window.markers['innkeep'] = L.layerGroup([
 			// Novigrad
 				L.marker([73.24, -44.21], setMarker(innkeepIcon)).bindLabel('The Golden Sturgen').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
 				L.marker([78.22, -33.49], setMarker(innkeepIcon)).bindLabel('Passiflora').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
@@ -558,7 +559,7 @@ $(function()
 				[-54.47, 12.00],
 		], monsterdenIcon, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby');
 
-		monsterdenMarkers = L.layerGroup($.merge(monsterdenGeneric, [
+		window.markers['monsterden'] = L.layerGroup($.merge(monsterdenGeneric, [
 			// NE Novigrad
 				L.marker([82.19, -32.08], setMarker(monsterdenIcon)).bindLabel('Monster Den').bindPopup('<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby (lvl 19<span> Golem</span>)'),
 			// S Novigrad
@@ -586,7 +587,7 @@ $(function()
 				[-68.69, -2.20],
 		], monsternestIcon, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
 
-		monsternestMarkers = L.layerGroup($.merge(monsternestGeneric, [
+		window.markers['monsternest'] = L.layerGroup($.merge(monsternestGeneric, [
 			// S Novigrad
 				L.marker([34.31, -60.51], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'),
 				L.marker([49.84, -45.97], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Endregas</span>)'),
@@ -614,7 +615,7 @@ $(function()
 			iconSize : [23, 28]
 		});
 
-		noticeMarkers = L.layerGroup(genericMarkers([
+		window.markers['notice'] = L.layerGroup(genericMarkers([
 			// Novigrad
 				[74.38, -34.06],
 				[73.00, -43.37],
@@ -656,7 +657,7 @@ $(function()
 				[-33.94, -132.36],
 		], pidIcon, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance');
 
-		pidMarkers = L.layerGroup($.merge(pidGeneric, [
+		window.markers['pid'] = L.layerGroup($.merge(pidGeneric, [
 			// SE Novigrad
 				L.marker([20.47, 100.55], setMarker(pidIcon)).bindLabel('Person(s) in Distress').bindPopup('<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance (lvl 9<span> Bandits</span>)'),
 			// NE Velen
@@ -672,7 +673,7 @@ $(function()
 		});
 
 		//todo get all place of power types
-		popMarkers = L.layerGroup([
+		window.markers['pop'] = L.layerGroup([
 			// Novigrad
 				L.marker([80.72, -40.83], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Igni</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
 			// E Novigrad
@@ -695,7 +696,7 @@ $(function()
 			iconSize : [28, 28]
 		});
 
-		poiMarkers = L.layerGroup([
+		window.markers['poi'] = L.layerGroup([
 			// Novigrad
 				L.marker([74.84, -25.88], setMarker(poiIcon)).bindLabel('Triss\' Residence').bindPopup('<h1>Triss\' Residence</h1>todo'),
 				L.marker([70.12, -28.76], setMarker(poiIcon)).bindLabel('Dandelion &amp; Zoltan\'s Residence').bindPopup('<h1>Dandelion &amp; Zoltan\'s Residence</h1>todo'),
@@ -729,7 +730,7 @@ $(function()
 			iconSize : [21, 30]
 		});
 
-		shopkeeperMarkers = L.layerGroup([
+		window.markers['shopkeeper'] = L.layerGroup([
 			// Novigrad
 				L.marker([74.22, -35.41], setMarker(shopkeeperIcon)).bindLabel('Book Merchant').bindPopup('<h1>Book Merchant</h1>Buys and sells books'),
 				L.marker([74.578, -35.332], setMarker(shopkeeperIcon)).bindLabel('Book Merchant').bindPopup('<h1>Book Merchant</h1>Buys and sells books'),
@@ -797,7 +798,7 @@ $(function()
 			iconSize : [27, 34]
 		});
 
-		signpostMarkers = L.layerGroup([
+		window.markers['signpost'] = L.layerGroup([
 			// Novigrad
 				L.marker([73.76, -33.97], setMarker(signpostIcon)).bindLabel('Hierarch Square').bindPopup('<h1>Hierarch Square</h1>Until quite recently a great many mages lived near Novigrad\'s main square. They fled when the witch hunters began their reign of terror, leaving many of the city\'s most beautiful townhouses abandoned and uncared for'),
 				L.marker([74.23, -15.86], setMarker(signpostIcon)).bindLabel('Southern Gate').bindPopup('<h1>Southern Gate</h1>In truth demarcating the eastern and not southern edge of the city, the Southern Gate was given its inappropriate name by a one-time city planner who knew nothing about architecture and could not read a map, but had in his favor the fact that he was the mayor\'s cousin and thew lavish parties. Though confusingly incorrect, the name stuck and now the city\'s residents never think twice about its illogical appellation'),
@@ -923,7 +924,7 @@ $(function()
 				[-58.90, -158.82],
 		], smugglersIcon, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
 
-		smugglersMarkers = L.layerGroup($.merge(smugglersGeneric, [
+		window.markers['smugglers'] = L.layerGroup($.merge(smugglersGeneric, [
 			// No custom markers needed
 		]));
 
@@ -933,7 +934,7 @@ $(function()
 			iconSize : [25, 28]
 		});
 
-		spoilsMarkers = L.layerGroup([
+		window.markers['spoils'] = L.layerGroup([
 			// NE Velen
 				L.marker([33.91, -68.51], setMarker(spoilsIcon)).bindLabel('Spoils of War').bindPopup('<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'),
 			// NW Velen
@@ -942,18 +943,32 @@ $(function()
 				L.marker([-74.75, -144.93], setMarker(spoilsIcon)).bindLabel('Spoils of War').bindPopup('<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish (lvl 10<span> Drowners</span>)'),
 		]);
 
-	allLayers = [abandonedMarkers, alchemyMarkers, armourerMarkers, armourerstableMarkers, banditcampMarkers, barberMarkers, blacksmithMarkers, brothelMarkers, entranceMarkers, grindstoneMarkers, guardedMarkers, gwentMarkers, harborMarkers, herbalistMarkers, hiddenMarkers, innkeepMarkers, monsterdenMarkers, monsternestMarkers, noticeMarkers, pidMarkers, popMarkers, poiMarkers, shopkeeperMarkers, signpostMarkers, smugglersMarkers, spoilsMarkers];
+	window.allLayers = [
+		window.markers['abandoned'],
+		window.markers['alchemy'],
+		window.markers['armourer'],
+		window.markers['armourerstable'],
+		window.markers['banditcamp'],
+		window.markers['barber'],
+		window.markers['blacksmith'],
+		window.markers['brothel'],
+		window.markers['entrance'],
+		window.markers['grindstone'],
+		window.markers['guarded'],
+		window.markers['gwent'],
+		window.markers['harbor'],
+		window.markers['herbalist'],
+		window.markers['hidden'],
+		window.markers['innkeep'],
+		window.markers['monsterden'],
+		window.markers['monsternest'],
+		window.markers['notice'],
+		window.markers['pid'],
+		window.markers['pop'],
+		window.markers['poi'],
+		window.markers['shopkeeper'],
+		window.markers['signpost'],
+		window.markers['smugglers'],
+		window.markers['spoils']
+	];
 });
-
-function genericMarkers(cords, icon, label, popup) {
-	var out = [];
-	$.each(cords, function(key, val)
-	{
-		out.push(L.marker(val, setMarker(icon)).bindLabel(label).bindPopup(popup));
-	});
-	return out;
-}
-
-function setMarker(icon, tooltip) {
-	return {icon : icon, riseOnHover : true};
-}

--- a/files/js/mapdata-velen.js
+++ b/files/js/mapdata-velen.js
@@ -1,974 +1,845 @@
-$(function() {
+(function () {
 	window.map_path   = 'velen';
 	window.map_sWest  = L.latLng(-85.05, -180);
 	window.map_nEast  = L.latLng(85.05, 135);
 	window.map_center = [60, -5];
 	window.map_mZoom  = 6;
 
-	window.markers = {};
+	var icons = window.icons;
+	var markers = window.markers;
 
 	// Abandoned Site
-		var abandonedIcon = L.icon({
-			iconUrl  : '/files/img/icons/abandoned.png',
-			iconSize : [30, 30]
-		});
+	var abandonedGeneric = genericMarkers([
+		// NW Velen
+			[-53.59, -56.34],
+			[-29.34, -136.23],
+			[-50.25, -140.63],
+			[-58.95, -142.21],
+	], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more');
 
-		var abandonedGeneric = genericMarkers([
-			// NW Velen
-				[-53.59, -56.34],
-				[-29.34, -136.23],
-				[-50.25, -140.63],
-				[-58.95, -142.21],
-		], abandonedIcon, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more');
-
-		window.markers['abandoned'] = L.layerGroup($.merge(abandonedGeneric, [
-			// NE Velen
-				L.marker([-17.06, 8.26], setMarker(abandonedIcon)).bindLabel('Abandoned Site').bindPopup('<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 4<span> Drowners</span>)'),
-				L.marker([13.70, 46.05], setMarker(abandonedIcon)).bindLabel('Abandoned Site').bindPopup('<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Drowners</span>)'),
-				L.marker([-8.23, 72.16], setMarker(abandonedIcon)).bindLabel('Abandoned Site').bindPopup('<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Ghouls</span> &amp; lvl 11<span> Alghoul</span>)'),
-			// SW Velen
-				L.marker([-79.70, -112.15], setMarker(abandonedIcon)).bindLabel('Abandoned Site').bindPopup('<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Bandits</span>)'),
-				L.marker([-78.68, -40.69], setMarker(abandonedIcon)).bindLabel('Abandoned Site').bindPopup('<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Endregas</span>)'),
-			// SE Velen
-				L.marker([-36.95, 3.08], setMarker(abandonedIcon)).bindLabel('Abandoned Site').bindPopup('<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 5<span> Bandits</span>)'),
-		]));
+	markers.abandoned = L.layerGroup($.merge(abandonedGeneric, [
+		// NE Velen
+			createMarker([-17.06, 8.26], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 4<span> Drowners</span>)'),
+			createMarker([13.70, 46.05], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Drowners</span>)'),
+			createMarker([-8.23, 72.16], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Ghouls</span> &amp; lvl 11<span> Alghoul</span>)'),
+		// SW Velen
+			createMarker([-79.70, -112.15], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Bandits</span>)'),
+			createMarker([-78.68, -40.69], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 9<span> Endregas</span>)'),
+		// SE Velen
+			createMarker([-36.95, 3.08], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more (lvl 5<span> Bandits</span>)'),
+	]));
 
 	// Alchemy Supplies
-		var alchemyIcon = L.icon({
-			iconUrl  : '/files/img/icons/alchemy.png',
-			iconSize : [20, 28]
-		});
-
-		window.markers['alchemy'] = L.layerGroup([
-			// Novigrad
-				L.marker([77.71, -15.91], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies*').bindPopup('<h1>Alchemy Supplies*</h1>Here you can buy alchemy ingredients, also pays well trophies'),
-				L.marker([79.75, -49.83], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies').bindPopup('<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
-			// NW Velen
-				L.marker([-18.52, -110.21], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies').bindPopup('<h1>Pellar</h1>Here you can buy alchemy ingredients'),
-		]);
+	markers.alchemy = L.layerGroup([
+		// Novigrad
+			createMarker([77.71, -15.91], icons.alchemy, 'Alchemy Supplies*', '<h1>Alchemy Supplies*</h1>Here you can buy alchemy ingredients, also pays well trophies'),
+			createMarker([79.75, -49.83], icons.alchemy, 'Alchemy Supplies', '<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
+		// NW Velen
+			createMarker([-18.52, -110.21], icons.alchemy, 'Alchemy Supplies', '<h1>Pellar</h1>Here you can buy alchemy ingredients'),
+	]);
 
 	// Armourer
-		var armourerIcon = L.icon({
-			iconUrl  : '/files/img/icons/armourer.png',
-			iconSize : [24, 34]
-		});
 
-		window.markers['armourer'] = L.layerGroup([
-			// Novigrad
-				L.marker([74.23, -38.23], setMarker(armourerIcon)).bindLabel('Journeyman Armorer').bindPopup('<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// Oxenfurt
-				L.marker([38.82, 54.01], setMarker(armourerIcon)).bindLabel('Journeyman Armorer').bindPopup('<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// NE Velen
-				L.marker([2.18, -12.92], setMarker(armourerIcon)).bindLabel('Amateur Armorer').bindPopup('<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// NW Velen
-				L.marker([-31.25, -71.02], setMarker(armourerIcon)).bindLabel('Journeyman Armorer').bindPopup('<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-				L.marker([-54.06, -122.97], setMarker(armourerIcon)).bindLabel('Amateur Armorer').bindPopup('<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-				L.marker([-30.87, -71.63], setMarker(armourerIcon)).bindLabel('Master Armorer*').bindPopup('<h1>Master Armorer* (Yoana)</h1>Is available after the \'Master Armorers\' (lvl 26) quest. Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		]);
+
+	markers.armourer = L.layerGroup([
+		// Novigrad
+			createMarker([74.23, -38.23], icons.armourer, 'Journeyman Armorer', '<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// Oxenfurt
+			createMarker([38.82, 54.01], icons.armourer, 'Journeyman Armorer', '<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// NE Velen
+			createMarker([2.18, -12.92], icons.armourer, 'Amateur Armorer', '<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// NW Velen
+			createMarker([-31.25, -71.02], icons.armourer, 'Journeyman Armorer', '<h1>Journeyman Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+			createMarker([-54.06, -122.97], icons.armourer, 'Amateur Armorer', '<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+			createMarker([-30.87, -71.63], icons.armourer, 'Master Armorer*', '<h1>Master Armorer* (Yoana)</h1>Is available after the \'Master Armorers\' (lvl 26) quest. Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+	]);
 
 	// Armourer's Table
-		var armourerstableIcon = L.icon({
-			iconUrl  : '/files/img/icons/armourerstable.png',
-			iconSize : [30, 27]
-		});
-
-		window.markers['armourerstable'] = L.layerGroup(genericMarkers([
-			// Novigrad
-				[75.27, -43.35],
-				[75.00, -40.68],
-			// Oxenfurt
-				[41.74, 51.23],
-			// NE Velen
-				[2.48, -12.42],
-			// NW Velen
-				[-29.07, -106.97],
-				[-30.41, -73.01],
-				[-63.95, -75.66],
-				[-54.01, -122.37],
-				[-59.04, -143.61],
-			// SE Velen
-				[-35.53, 54.58],
-				[-33.60, -26.28],
-		], armourerstableIcon, 'Armorer\'s Table', '<h1>Armorer\'s Table</h1>Armorer\'s tables grant your gear increased armor for a limited duration'));
+	markers.armourerstable = L.layerGroup(genericMarkers([
+		// Novigrad
+			[75.27, -43.35],
+			[75.00, -40.68],
+		// Oxenfurt
+			[41.74, 51.23],
+		// NE Velen
+			[2.48, -12.42],
+		// NW Velen
+			[-29.07, -106.97],
+			[-30.41, -73.01],
+			[-63.95, -75.66],
+			[-54.01, -122.37],
+			[-59.04, -143.61],
+		// SE Velen
+			[-35.53, 54.58],
+			[-33.60, -26.28],
+	], icons.armourerstable, 'Armorer\'s Table', '<h1>Armorer\'s Table</h1>Armorer\'s tables grant your gear increased armor for a limited duration'));
 
 	// Bandit Camp
-		var banditcampIcon = L.icon({
-			iconUrl  : '/files/img/icons/banditcamp.png',
-			iconSize : [29, 30]
-		});
+	var banditcampGeneric = genericMarkers([
+		// NE Velen
+			[11.61, -54.42],
+		// NW Velen
+			[-23.92, -95.51],
+			[-42.81, -128.14],
+			[-48.69, -130.78],
+			[-51.67, -133.59],
+			[-40.18, -136.49],
+			[-61.14, -145.81],
+			[-57.70, -154.75],
+		// SW Velen
+			[-64.55, -146.69],
+			[-65.04, -142.34],
+		// SE Velen
+			[-29.69, -17.23],
+	], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here');
 
-		var banditcampGeneric = genericMarkers([
-			// NE Velen
-				[11.61, -54.42],
-			// NW Velen
-				[-23.92, -95.51],
-				[-42.81, -128.14],
-				[-48.69, -130.78],
-				[-51.67, -133.59],
-				[-40.18, -136.49],
-				[-61.14, -145.81],
-				[-57.70, -154.75],
-			// SW Velen
-				[-64.55, -146.69],
-				[-65.04, -142.34],
-			// SE Velen
-				[-29.69, -17.23],
-		], banditcampIcon, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here');
-
-		window.markers['banditcamp'] = L.layerGroup($.merge(banditcampGeneric, [
-			// S Novigrad
-				L.marker([55.43, -63.00], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-			// E Novigrad
-				L.marker([74.40, 49.06], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 7)'),
-			// NE Velen
-				L.marker([0.53, 33.05], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-				L.marker([8.67, 1.76], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-			// SE Velen
-				L.marker([-77.24, 36.69], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 10)'),
-				L.marker([-53.33, 54.49], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-				L.marker([-26.90, 24.43], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-				L.marker([-38.96, -4.75], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 7-9)'),
-				L.marker([13.37, 84.36], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-				L.marker([-74.40, -6.81], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
-			// SW Velen
-				L.marker([-69.81, -142.91], setMarker(banditcampIcon)).bindLabel('Bandit Camp').bindPopup('<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here. Bugged area, never shows as cleared'),
-		]));
+	markers.banditcamp = L.layerGroup($.merge(banditcampGeneric, [
+		// S Novigrad
+			createMarker([55.43, -63.00], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
+		// E Novigrad
+			createMarker([74.40, 49.06], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 7)'),
+		// NE Velen
+			createMarker([0.53, 33.05], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
+			createMarker([8.67, 1.76], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
+		// SE Velen
+			createMarker([-77.24, 36.69], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 10)'),
+			createMarker([-53.33, 54.49], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
+			createMarker([-26.90, 24.43], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
+			createMarker([-38.96, -4.75], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 7-9)'),
+			createMarker([13.37, 84.36], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
+			createMarker([-74.40, -6.81], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here (lvl 9)'),
+		// SW Velen
+			createMarker([-69.81, -142.91], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here. Bugged area, never shows as cleared'),
+	]));
 
 	// Barber
-		var barberIcon = L.icon({
-			iconUrl  : '/files/img/icons/barber.png',
-			iconSize : [30, 30]
-		});
-
-		window.markers['barber'] = L.layerGroup(genericMarkers([
-			// Novigrad
-				[76.45, -33.18],
-				[76.32, -20.39],
-			// Oxenfurt
-				[33.87, 52.12],
-			// NW Velen
-				[-54.36, -81.81],
-		], barberIcon, 'Barber', '<h1>Barber</h1>Visit barbers for a shave or a new haircut'));
+	markers.barber = L.layerGroup(genericMarkers([
+		// Novigrad
+			[76.45, -33.18],
+			[76.32, -20.39],
+		// Oxenfurt
+			[33.87, 52.12],
+		// NW Velen
+			[-54.36, -81.81],
+	], icons.barber, 'Barber', '<h1>Barber</h1>Visit barbers for a shave or a new haircut'));
 
 	// Blacksmith
-		var blacksmithIcon = L.icon({
-			iconUrl  : '/files/img/icons/blacksmith.png',
-			iconSize : [27, 30]
-		});
-
-		window.markers['blacksmith'] = L.layerGroup([
-			// Novigrad
-				L.marker([69.15, -41.00], setMarker(blacksmithIcon)).bindLabel('Master Blacksmith*').bindPopup('<h1>Master Blacksmith</h1>You must complete "Of Swords and Dumplings" (level 24) quest in order to unlock this blacksmith. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-				L.marker([73.14, -37.96], setMarker(blacksmithIcon)).bindLabel('Journeyman Blacksmith').bindPopup('<h1>Journeyman Blacksmith</h1>This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-				L.marker([75.17, -43.15], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// Oxenfurt
-				L.marker([32.00, 59.77], setMarker(blacksmithIcon)).bindLabel('Journeyman Blacksmith').bindPopup('<h1>Journeyman Blacksmith</h1>This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// NW Velen
-				L.marker([-29.27, -106.47], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-				L.marker([-64.28, -75.87], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-			// SE Velen
-				L.marker([-32.96, -26.91], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		]);
+	markers.blacksmith = L.layerGroup([
+		// Novigrad
+			createMarker([69.15, -41.00], icons.blacksmith, 'Master Blacksmith*', '<h1>Master Blacksmith</h1>You must complete "Of Swords and Dumplings" (level 24) quest in order to unlock this blacksmith. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+			createMarker([73.14, -37.96], icons.blacksmith, 'Journeyman Blacksmith', '<h1>Journeyman Blacksmith</h1>This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+			createMarker([75.17, -43.15], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// Oxenfurt
+			createMarker([32.00, 59.77], icons.blacksmith, 'Journeyman Blacksmith', '<h1>Journeyman Blacksmith</h1>This blacksmith is available immediately. Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// NW Velen
+			createMarker([-29.27, -106.47], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+			createMarker([-64.28, -75.87], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+		// SE Velen
+			createMarker([-32.96, -26.91], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+	]);
 
 	// Brothel
-		var brothelIcon = L.icon({
-			iconUrl  : '/files/img/icons/brothel.png',
-			iconSize : [28, 26]
-		});
-
-		window.markers['brothel'] = L.layerGroup([
-			// Novigrad
-				L.marker([71.22, -41.84], setMarker(brothelIcon)).bindLabel('Crippled Kate').bindPopup('<h1>Crippled Kate Brothel</h1>You can call on the services of a prostitute here'),
-				L.marker([78.34, -33.40], setMarker(brothelIcon)).bindLabel('Passiflora').bindPopup('<h1>Passiflora Brothel</h1>You can call on the services of a prostitute here')
-		]);
+	markers.brothel = L.layerGroup([
+		// Novigrad
+			createMarker([71.22, -41.84], icons.brothel, 'Crippled Kate', '<h1>Crippled Kate Brothel</h1>You can call on the services of a prostitute here'),
+			createMarker([78.34, -33.40], icons.brothel, 'Passiflora', '<h1>Passiflora Brothel</h1>You can call on the services of a prostitute here')
+	]);
 
 	// Boat
 /*
-		var boatIcon = L.icon({
-			iconUrl  : '/files/img/icons/boat.png',
-			iconSize : [30, 28]
-		});
 
-		window.markers['boat'] = L.layerGroup(genericMarkers([
-			// Novigrad
-				[69.84, -13.01],
-				[72.82, -10.28],
-				[77.92, -44.38],
-				[76.98, -47.29],
-				[76.92, -50.10],
-				[70.23, -46.47],
-				[70.03, -52.69],
-				[70.64, -58.93],
-				[73.64, -54.99],
-				[73.26, -52.57],
-			// NE Novigrad
-				[82.32, -53.51],
-				[81.33, -34.10],
-			// E Novigrad
-				[65.04, 19.78],
-			// S Novigrad
-				[67.41, -72.33],
-				[56.32, -3.89],
-				[47.36, -58.43],
-				[38.62, -61.56],
-				[30.83, -59.94],
-				[35.10, -28.19],
-			// Oxenfurt
-				[46.56, 49.37],
-				[36.03, 67.94],
-				[34.23, 61.00],
-				[28.23, 62.49],
-				[24.69, 54.23],
-				[29.38, 48.06],
-				[15.31, 68.73],
-			// NE Velen
-				[-7.19, 65.13],
-				[-0.97, 68.82],
-				[38.82, 39.55],
-				[51.45, 10.50],
-				[-19.10, 7.38],
-				[-18.40, -32.93],
-			// NW Velen
-				[-26.12, -31.38],
-				[-51.99, -34.10],
-				[-54.32, -54.32],
-				[-69.89, -33.44],
-				[-65.33, -64.47],
-				[-65.35, -81.43],
-				[-65.78, -82.31],
-				[-63.80, -125.46],
-				[-41.54, -142.82],
-				[-27.64, -121.82],
-			// SW Velen
-				[-73.48, -142.91],
-				[-74.04, -104.24],
-				[-77.06, -40.96],
-				[-71.90, -73.92],
-				[-80.18, -114.17],
-			// SE Velen
-				[-68.84, -4.48],
-		], boatIcon, 'Boat', '<h1>Boat</h1>You can use boats to travel across bodies of water'));
+
+	markers.boat = L.layerGroup(genericMarkers([
+		// Novigrad
+			[69.84, -13.01],
+			[72.82, -10.28],
+			[77.92, -44.38],
+			[76.98, -47.29],
+			[76.92, -50.10],
+			[70.23, -46.47],
+			[70.03, -52.69],
+			[70.64, -58.93],
+			[73.64, -54.99],
+			[73.26, -52.57],
+		// NE Novigrad
+			[82.32, -53.51],
+			[81.33, -34.10],
+		// E Novigrad
+			[65.04, 19.78],
+		// S Novigrad
+			[67.41, -72.33],
+			[56.32, -3.89],
+			[47.36, -58.43],
+			[38.62, -61.56],
+			[30.83, -59.94],
+			[35.10, -28.19],
+		// Oxenfurt
+			[46.56, 49.37],
+			[36.03, 67.94],
+			[34.23, 61.00],
+			[28.23, 62.49],
+			[24.69, 54.23],
+			[29.38, 48.06],
+			[15.31, 68.73],
+		// NE Velen
+			[-7.19, 65.13],
+			[-0.97, 68.82],
+			[38.82, 39.55],
+			[51.45, 10.50],
+			[-19.10, 7.38],
+			[-18.40, -32.93],
+		// NW Velen
+			[-26.12, -31.38],
+			[-51.99, -34.10],
+			[-54.32, -54.32],
+			[-69.89, -33.44],
+			[-65.33, -64.47],
+			[-65.35, -81.43],
+			[-65.78, -82.31],
+			[-63.80, -125.46],
+			[-41.54, -142.82],
+			[-27.64, -121.82],
+		// SW Velen
+			[-73.48, -142.91],
+			[-74.04, -104.24],
+			[-77.06, -40.96],
+			[-71.90, -73.92],
+			[-80.18, -114.17],
+		// SE Velen
+			[-68.84, -4.48],
+	], icons.boat, 'Boat', '<h1>Boat</h1>You can use boats to travel across bodies of water'));
 */
 	// Entrance
-		var entranceIcon = L.icon({
-			iconUrl  : '/files/img/icons/entrance.png',
-			iconSize : [28, 27]
-		});
-
-		// todo, entrance to what?
-		window.markers['entrance'] = L.layerGroup([
-			// Novigrad
-				L.marker([80.68, -55.02], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// NE Novigrad
-				L.marker([82.18, 32.78], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// SE Novigrad
-				L.marker([58.34, 66.68], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([61.02, 89.12], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([36.43, 114.21], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// S Novigrad
-				L.marker([53.96, -71.48], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// NE Velen
-				L.marker([27.06, -29.27], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// NW Velen
-				L.marker([3.05, -122.17], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-26.70, -63.75], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-28.77, -77.74], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// SW Velen
-				L.marker([-75.36, -124.19], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-76.32, -114.87], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-			// SE Velen
-				L.marker([-71.64, -1.67], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-70.16, 39.55], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-48.52, -29.03], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-22.84, 72.02], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-56.51, 80.33], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-43.71, 39.20], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-35.32, 69.74], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-38.00, 70.36], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-79.628, 2.351], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-52.670, 31.069], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-75.834, 50.361], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-		]);
+	// todo, entrance to what?
+	markers.entrance = L.layerGroup([
+		// Novigrad
+			createMarker([80.68, -55.02], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// NE Novigrad
+			createMarker([82.18, 32.78], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// SE Novigrad
+			createMarker([58.34, 66.68], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([61.02, 89.12], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([36.43, 114.21], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// S Novigrad
+			createMarker([53.96, -71.48], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// NE Velen
+			createMarker([27.06, -29.27], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// NW Velen
+			createMarker([3.05, -122.17], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-26.70, -63.75], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-28.77, -77.74], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// SW Velen
+			createMarker([-75.36, -124.19], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-76.32, -114.87], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		// SE Velen
+			createMarker([-71.64, -1.67], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-70.16, 39.55], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-48.52, -29.03], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-22.84, 72.02], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-56.51, 80.33], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-43.71, 39.20], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-35.32, 69.74], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-38.00, 70.36], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-79.628, 2.351], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-52.670, 31.069], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+			createMarker([-75.834, 50.361], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+	]);
 
 	// Grindstone
-		var grindstoneIcon = L.icon({
-			iconUrl  : '/files/img/icons/grindstone.png',
-			iconSize : [30, 26]
-		});
-
-		window.markers['grindstone'] = L.layerGroup(genericMarkers([
-			// Novigrad
-				[75.27, -42.95],
-				[74.96, -40.28],
-			// S Novigrad
-				[48.86, -51.39],
-			// Oxenfurt
-				[41.64, 51.53],
-			// NE Velen
-				[2.48, -13.42],
-			// NW Velen
-				[32.84, -114.26],
-				[-29.07, -105.97],
-				[-30.64, -72.55],
-				[-53.67, -80.20],
-				[-64.05, -75.06],
-				[-54.01, -123.57],
-				[-59.09, -144.05],
-			// SE Velen
-				[-35.89, 55.20],
-				[-33.80, -26.81],
-		], grindstoneIcon, 'Grindstone', '<h1>Grindstone</h1>A blade sharpened here will deal more damage'));
+	markers.grindstone = L.layerGroup(genericMarkers([
+		// Novigrad
+			[75.27, -42.95],
+			[74.96, -40.28],
+		// S Novigrad
+			[48.86, -51.39],
+		// Oxenfurt
+			[41.64, 51.53],
+		// NE Velen
+			[2.48, -13.42],
+		// NW Velen
+			[32.84, -114.26],
+			[-29.07, -105.97],
+			[-30.64, -72.55],
+			[-53.67, -80.20],
+			[-64.05, -75.06],
+			[-54.01, -123.57],
+			[-59.09, -144.05],
+		// SE Velen
+			[-35.89, 55.20],
+			[-33.80, -26.81],
+	], icons.grindstone, 'Grindstone', '<h1>Grindstone</h1>A blade sharpened here will deal more damage'));
 
 	// Guarded Treasure
-		var guardedIcon = L.icon({
-			iconUrl  : '/files/img/icons/guarded.png',
-			iconSize : [23, 34]
-		});
+	var guardedGeneric = genericMarkers([
+		// NE Velen
+			[22.51, -56.78],
+		// NW Velen
+			[-28.07, -119.66],
+			[-38.62, -123.40],
+			[-38.27, -149.24],
+		// SE Velen
+			[-73.42, 31.77],
+			[-51.78, -6.42],
+	], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
 
-		var guardedGeneric = genericMarkers([
-			// NE Velen
-				[22.51, -56.78],
-			// NW Velen
-				[-28.07, -119.66],
-				[-38.62, -123.40],
-				[-38.27, -149.24],
-			// SE Velen
-				[-73.42, 31.77],
-				[-51.78, -6.42],
-		], guardedIcon, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
-
-		window.markers['guarded'] = L.layerGroup($.merge(guardedGeneric, [
-			// NE Novigrad
-				L.marker([76.43, -2.07], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'),
-				L.marker([80.52, -4.53], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 15<span> Bilge Hag</span>) guards a valuable cache here'),
-				L.marker([82.61, -33.49], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 23<span> Armored Arachas</span>) guards a valuable cache here'),
-			// SE Novigrad
-				L.marker([45.62, 99.05], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 20<span> Leshen</span>) guards a valuable cache here'),
-			// S Novigrad
-				L.marker([51.97, -12.00], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 18<span> Wyvern</span>) guards a valuable cache here'),
-				L.marker([62.00, -97.38], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 15<span> Noonwraith</span>) guards a valuable cache here'),
-			// NE Velen
-				L.marker([-8.93, 12.30], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 13<span> Alghoul</span>) guards a valuable cache here'),
-				L.marker([-7.89, 55.37], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 9<span> Drowners</span>) guards a valuable cache here'),
-			// NW Velen
-				L.marker([4.193, -82.463], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>Available after the \'Master Armorers\' (lvl 26) quest. A particularly powerful monster guards a valuable cache here'),
-				L.marker([-62.39, -118.17], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 7<span> Wraiths</span>) guards a valuable cache here'),
-				L.marker([-43.55, -40.08], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 14<span> Forktail</span>) guards a valuable cache here'),
-				L.marker([-45.61, -152.31], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 4<span> Drowners</span>) guards a valuable cache here'),
-				L.marker([25.96, -99.67], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 14<span> Basilisk</span>) guards a valuable cache here'),
-			// SW Velen
-				L.marker([-77.77, -102.04], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'),
-				L.marker([-81.30, -69.74], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 18<span> Noonwraith/Nightwraith</span>) guards a valuable cache here'),
-				L.marker([-82.20, -69.57], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 19<span> Gargoyle</span>) guards a valuable cache here'),
-				L.marker([-78.56, -48.91], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 13<span> Alghoul</span>) guards a valuable cache here'),
-			// SE Velen
-				L.marker([-70.260, 102.440], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 24<span> Earth Elemental</span>) guards a valuable cache here'),
-				L.marker([-75.81, 30.63], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 20<span> Bilge Hag</span>) guards a valuable cache here'),
-				L.marker([-80.190, 28.870], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 14<span> Wyvern</span>) guards a valuable cache here'),
-				L.marker([-81.11, 31.33], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 19<span> Cyclops</span>) guards a valuable cache here'),
-				L.marker([-63.27, 48.87], setMarker(guardedIcon)).bindLabel('Guarded Treasure').bindPopup('<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'),
-		]));
+	markers.guarded = L.layerGroup($.merge(guardedGeneric, [
+		// NE Novigrad
+			createMarker([76.43, -2.07], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'),
+			createMarker([80.52, -4.53], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 15<span> Bilge Hag</span>) guards a valuable cache here'),
+			createMarker([82.61, -33.49], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 23<span> Armored Arachas</span>) guards a valuable cache here'),
+		// SE Novigrad
+			createMarker([45.62, 99.05], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 20<span> Leshen</span>) guards a valuable cache here'),
+		// S Novigrad
+			createMarker([51.97, -12.00], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 18<span> Wyvern</span>) guards a valuable cache here'),
+			createMarker([62.00, -97.38], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 15<span> Noonwraith</span>) guards a valuable cache here'),
+		// NE Velen
+			createMarker([-8.93, 12.30], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 13<span> Alghoul</span>) guards a valuable cache here'),
+			createMarker([-7.89, 55.37], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 9<span> Drowners</span>) guards a valuable cache here'),
+		// NW Velen
+			createMarker([4.193, -82.463], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>Available after the \'Master Armorers\' (lvl 26) quest. A particularly powerful monster guards a valuable cache here'),
+			createMarker([-62.39, -118.17], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 7<span> Wraiths</span>) guards a valuable cache here'),
+			createMarker([-43.55, -40.08], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 14<span> Forktail</span>) guards a valuable cache here'),
+			createMarker([-45.61, -152.31], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 4<span> Drowners</span>) guards a valuable cache here'),
+			createMarker([25.96, -99.67], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 14<span> Basilisk</span>) guards a valuable cache here'),
+		// SW Velen
+			createMarker([-77.77, -102.04], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'),
+			createMarker([-81.30, -69.74], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 18<span> Noonwraith/Nightwraith</span>) guards a valuable cache here'),
+			createMarker([-82.20, -69.57], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 19<span> Gargoyle</span>) guards a valuable cache here'),
+			createMarker([-78.56, -48.91], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 13<span> Alghoul</span>) guards a valuable cache here'),
+		// SE Velen
+			createMarker([-70.260, 102.440], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 24<span> Earth Elemental</span>) guards a valuable cache here'),
+			createMarker([-75.81, 30.63], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 20<span> Bilge Hag</span>) guards a valuable cache here'),
+			createMarker([-80.190, 28.870], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 14<span> Wyvern</span>) guards a valuable cache here'),
+			createMarker([-81.11, 31.33], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 19<span> Cyclops</span>) guards a valuable cache here'),
+			createMarker([-63.27, 48.87], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster (lvl 8<span> Water Hag</span>) guards a valuable cache here'),
+	]));
 
 	// Gwent Player
-		var gwentIcon = L.icon({
-			iconUrl  : '/files/img/icons/gwent.png',
-			iconSize : [24, 30]
-		});
-
-		window.markers['gwent'] = L.layerGroup([
-			// Novigrad
-				L.marker([74.618, -35.132], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Book Merchant Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([71.00, -41.90], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Crippled Kate Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([78.25, -33.79], setMarker(gwentIcon)).bindLabel('Gwent Tournament').bindPopup('<h1>Gwent Tournament (Quest)</h1>Find the scribe and sign up for the high-stakes Gwent tournament'),
-				L.marker([72.58, -26.21], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([70.15, -36.93], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([71.43, -35.51], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Herbalist Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([70.14, -1.45], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([70.00, -20.27], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Merchant Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([70.12, -29.16], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([73.32, -43.81], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([76.25, -23.95], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([73.20, -37.66], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([73.81, -37.76], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Banker Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([74.52, -46.63], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Fishmonger Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([75.37, -43.15], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([75.49, -44.62], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([76.87, -33.02], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([75.04, -20.82], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([75.39, -19.02], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Loan Shark Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([79.80, -49.53], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Alchemist Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([77.77, -15.58], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Alchemist Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([74.55, -32.41], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Player</h1>Warning, this player may disappear later in the game. Gamble your hard earned coin playing Gwent here'),
-			// S Novigrad
-				L.marker([62.43, -14.22], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			// SE Novigrad
-				L.marker([50.64, 72.27], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Herbalist Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			// Oxenfurt
-				L.marker([36.56, 52.47], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([38.92, 54.21], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([40.11, 51.68], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([32.20, 59.87], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			// NE Velen
-				L.marker([2.58, -12.92], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			// NW Velen
-				L.marker([-27.64, -102.54], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-28.87, -106.47], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-34.76, -72.57], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-31.90, -71.52], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Quartermaster Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-31.15, -70.82], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-28.39, -75.45], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Bloody Baron Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-52.60, -81.19], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-62.53, -76.44], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-54.27, -121.56], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-53.86, -122.97], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-30.67, -71.43], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Yoana (Armorer\'s assistant) Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-			// SE Velen
-				L.marker([-36.78, -24.15], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-32.76, -26.61], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-78.74, 108.44], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Quartermaster Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
-				L.marker([-57.20, 27.23], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Gwent Player</h1>This Gwent player disappears sometime after the \'Family matters\' quest. Gamble your hard earned coin playing Gwent here'),
-		]);
+	markers.gwent = L.layerGroup([
+		// Novigrad
+			createMarker([74.618, -35.132], icons.gwent, 'Gwent Player', '<h1>Book Merchant Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([71.00, -41.90], icons.gwent, 'Gwent Player', '<h1>Crippled Kate Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([78.25, -33.79], icons.gwent, 'Gwent Tournament', '<h1>Gwent Tournament (Quest)</h1>Find the scribe and sign up for the high-stakes Gwent tournament'),
+			createMarker([72.58, -26.21], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([70.15, -36.93], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([71.43, -35.51], icons.gwent, 'Gwent Player', '<h1>Herbalist Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([70.14, -1.45], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([70.00, -20.27], icons.gwent, 'Gwent Player', '<h1>Merchant Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([70.12, -29.16], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([73.32, -43.81], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([76.25, -23.95], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([73.20, -37.66], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([73.81, -37.76], icons.gwent, 'Gwent Player', '<h1>Banker Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([74.52, -46.63], icons.gwent, 'Gwent Player', '<h1>Fishmonger Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([75.37, -43.15], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([75.49, -44.62], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([76.87, -33.02], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([75.04, -20.82], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([75.39, -19.02], icons.gwent, 'Gwent Player', '<h1>Loan Shark Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([79.80, -49.53], icons.gwent, 'Gwent Player', '<h1>Alchemist Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([77.77, -15.58], icons.gwent, 'Gwent Player', '<h1>Alchemist Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([74.55, -32.41], icons.gwent, 'Gwent Player', '<h1>Innkeeper Player</h1>Warning, this player may disappear later in the game. Gamble your hard earned coin playing Gwent here'),
+		// S Novigrad
+			createMarker([62.43, -14.22], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+		// SE Novigrad
+			createMarker([50.64, 72.27], icons.gwent, 'Gwent Player', '<h1>Herbalist Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+		// Oxenfurt
+			createMarker([36.56, 52.47], icons.gwent, 'Gwent Player', '<h1>Innkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([38.92, 54.21], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([40.11, 51.68], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([32.20, 59.87], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+		// NE Velen
+			createMarker([2.58, -12.92], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+		// NW Velen
+			createMarker([-27.64, -102.54], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-28.87, -106.47], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-34.76, -72.57], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-31.90, -71.52], icons.gwent, 'Gwent Player', '<h1>Quartermaster Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-31.15, -70.82], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-28.39, -75.45], icons.gwent, 'Gwent Player', '<h1>Bloody Baron Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-52.60, -81.19], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-62.53, -76.44], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-54.27, -121.56], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-53.86, -122.97], icons.gwent, 'Gwent Player', '<h1>Armorer Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-30.67, -71.43], icons.gwent, 'Gwent Player', '<h1>Yoana (Armorer\'s assistant) Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+		// SE Velen
+			createMarker([-36.78, -24.15], icons.gwent, 'Gwent Player', '<h1>Shopkeeper Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-32.76, -26.61], icons.gwent, 'Gwent Player', '<h1>Blacksmith Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-78.74, 108.44], icons.gwent, 'Gwent Player', '<h1>Quartermaster Gwent Player</h1>Gamble your hard earned coin playing Gwent here'),
+			createMarker([-57.20, 27.23], icons.gwent, 'Gwent Player', '<h1>Gwent Player</h1>This Gwent player disappears sometime after the \'Family matters\' quest. Gamble your hard earned coin playing Gwent here'),
+	]);
 
 	// Harbor
-		var harborIcon = L.icon({
-			iconUrl  : '/files/img/icons/harbor.png',
-			iconSize : [27, 30]
-		});
-
-		window.markers['harbor'] = L.layerGroup(genericMarkers([
-			// Novigrad
-				[70.64, -58.93],
-			// Oxenfurt
-				[38.17, 46.85],
-			// NE Velen
-				[-6.53, 62.93],
-				[-19.10, 9.49],
-				[-18.40, -32.93],
-			// NW Velen
-				[-54.32, -54.32],
-				[-41.54, -142.82],
-				[-27.64, -121.82],
-			// SW Velen
-				[-71.90, -73.92],
-				[-80.18, -114.17],
-			// SE Velen
-				[-78.78, -11.07],
-		], harborIcon, 'Harbor', '<h1>Harbor</h1>A place where you can find a boat, boats will respawn here'));
+	markers.harbor = L.layerGroup(genericMarkers([
+		// Novigrad
+			[70.64, -58.93],
+		// Oxenfurt
+			[38.17, 46.85],
+		// NE Velen
+			[-6.53, 62.93],
+			[-19.10, 9.49],
+			[-18.40, -32.93],
+		// NW Velen
+			[-54.32, -54.32],
+			[-41.54, -142.82],
+			[-27.64, -121.82],
+		// SW Velen
+			[-71.90, -73.92],
+			[-80.18, -114.17],
+		// SE Velen
+			[-78.78, -11.07],
+	], icons.harbor, 'Harbor', '<h1>Harbor</h1>A place where you can find a boat, boats will respawn here'));
 
 	// Herbalist
-		var herbalistIcon = L.icon({
-			iconUrl  : '/files/img/icons/herbalist.png',
-			iconSize : [25, 28]
-		});
+	var herbalistGeneric = genericMarkers([
+		// Novigrad
+			[73.65, -34.89],
+			[71.33, -35.51],
+		// S Novigrad
+			[61.89, -13.16],
+		// SE Novigrad
+			[50.54, 72.07],
+	], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>Here you can buy alchemy ingredients');
 
-		var herbalistGeneric = genericMarkers([
-			// Novigrad
-				[73.65, -34.89],
-				[71.33, -35.51],
-			// S Novigrad
-				[61.89, -13.16],
-			// SE Novigrad
-				[50.54, 72.07],
-		], herbalistIcon, 'Herbalist', '<h1>Herbalist</h1>Here you can buy alchemy ingredients');
-
-		window.markers['herbalist'] = L.layerGroup($.merge(herbalistGeneric, [
-			// NW Velen
-				L.marker([-50.26, -138.91], setMarker(herbalistIcon)).bindLabel('Herbalist').bindPopup('<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
-				L.marker([-28.15, -135.26], setMarker(herbalistIcon)).bindLabel('Herbalist').bindPopup('<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
-			// SW Velen
-				L.marker([-78.53, -41.44], setMarker(herbalistIcon)).bindLabel('Herbalist').bindPopup('<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
-			// SE Velen
-				L.marker([-36.92, 2.37], setMarker(herbalistIcon)).bindLabel('Herbalist').bindPopup('<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
-		]));
+	markers.herbalist = L.layerGroup($.merge(herbalistGeneric, [
+		// NW Velen
+			createMarker([-50.26, -138.91], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
+			createMarker([-28.15, -135.26], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
+		// SW Velen
+			createMarker([-78.53, -41.44], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
+		// SE Velen
+			createMarker([-36.92, 2.37], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
+	]));
 
 
 	// Hidden Treasure
-		var hiddenIcon = L.icon({
-			iconUrl  : '/files/img/icons/hidden.png',
-			iconSize : [23, 34]
-		});
+	var hiddenGeneric = genericMarkers([
+		// NW Velen
+			[33.06, -115.25],
+			[-27.92, -128.06],
+			[-31.65, -143.17],
+			[-42.33, -140.33],
+		// SW Velen
+			[-71.34, -107.75],
+		// SE Velen
+			[-29.99, 28.39],
+	], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
 
-		var hiddenGeneric = genericMarkers([
-			// NW Velen
-				[33.06, -115.25],
-				[-27.92, -128.06],
-				[-31.65, -143.17],
-				[-42.33, -140.33],
-			// SW Velen
-				[-71.34, -107.75],
-			// SE Velen
-				[-29.99, 28.39],
-		], hiddenIcon, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
-
-		window.markers['hidden'] = L.layerGroup($.merge(hiddenGeneric, [
-			// S Novigrad
-				L.marker([34.55, -43.68], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 6<span> Nekkers</span>)'),
-				L.marker([49.38, -68.91], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 15<span> Mucknixers</span>)'),
-			// NE Velen
-				L.marker([-16.89, 10.06], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 10<span> Drowners</span>)'),
-				L.marker([3.03, 64.56], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
-				L.marker([45.49, 26.76], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
-				L.marker([-3.51, 21.40], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Foglet</span>)'),
-				L.marker([52.35, 16.17], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 18<span> Bilge Hag</span>)'),
-				L.marker([47.72, 38.50], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 26+<span> Basilisk</span>)'),
-			// NW Velen
-				L.marker([-50.76, -155.04], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
-			// SE Velen
-				L.marker([-72.84, 77.08], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 22<span> Fiend</span>)'),
-				L.marker([-37.16, 97.29], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Foglets</span>)'),
-				L.marker([-20.96, 48.78], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 9<span> Bandits</span>)'),
-			// SW Velen
-				L.marker([-70.50, -150.64], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 25+<span> Grave Hag</span>)'),
-				L.marker([-72.78, -131.40], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 10<span> Bandits</span>)'),
-				L.marker([-71.09, -109.96], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 13<span> Wraiths</span>)'),
-				L.marker([-76.90, -80.68], setMarker(hiddenIcon)).bindLabel('Hidden Treasure').bindPopup('<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
-		]));
+	markers.hidden = L.layerGroup($.merge(hiddenGeneric, [
+		// S Novigrad
+			createMarker([34.55, -43.68], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 6<span> Nekkers</span>)'),
+			createMarker([49.38, -68.91], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 15<span> Mucknixers</span>)'),
+		// NE Velen
+			createMarker([-16.89, 10.06], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 10<span> Drowners</span>)'),
+			createMarker([3.03, 64.56], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
+			createMarker([45.49, 26.76], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
+			createMarker([-3.51, 21.40], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Foglet</span>)'),
+			createMarker([52.35, 16.17], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 18<span> Bilge Hag</span>)'),
+			createMarker([47.72, 38.50], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 26+<span> Basilisk</span>)'),
+		// NW Velen
+			createMarker([-50.76, -155.04], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
+		// SE Velen
+			createMarker([-72.84, 77.08], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 22<span> Fiend</span>)'),
+			createMarker([-37.16, 97.29], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Foglets</span>)'),
+			createMarker([-20.96, 48.78], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 9<span> Bandits</span>)'),
+		// SW Velen
+			createMarker([-70.50, -150.64], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 25+<span> Grave Hag</span>)'),
+			createMarker([-72.78, -131.40], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 10<span> Bandits</span>)'),
+			createMarker([-71.09, -109.96], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 13<span> Wraiths</span>)'),
+			createMarker([-76.90, -80.68], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods (Guarded by lvl 4<span> Drowners</span>)'),
+	]));
 
 	// Innkeep
-		var innkeepIcon = L.icon({
-			iconUrl  : '/files/img/icons/tavern.png',
-			iconSize : [26, 30]
-		});
-
-		window.markers['innkeep'] = L.layerGroup([
-			// Novigrad
-				L.marker([73.24, -44.21], setMarker(innkeepIcon)).bindLabel('The Golden Sturgen').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-				L.marker([78.22, -33.49], setMarker(innkeepIcon)).bindLabel('Passiflora').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-				L.marker([76.20, -24.35], setMarker(innkeepIcon)).bindLabel('The Nowhere').bindPopup('<h1>Innkeep</h1>Sells Food and drink'),
-				L.marker([70.02, -29.56], setMarker(innkeepIcon)).bindLabel('Rosemary &amp; Thyme').bindPopup('<h1>Innkeep</h1>Sells Food and drink'),
-				L.marker([70.04, -1.85], setMarker(innkeepIcon)).bindLabel('Seven Cats Inn').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-				L.marker([74.50, -32.61], setMarker(innkeepIcon)).bindLabel('The Kingfisher').bindPopup('<h1>The Kingfisher</h1>Warning, this trader may disappear later in the game. Sells Gwent cards, food, and drink'),
-			// S Novigrad
-				L.marker([62.33, -14.02], setMarker(innkeepIcon)).bindLabel('Cunny of the Goose').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-			// Oxenfurt
-				L.marker([36.46, 52.27], setMarker(innkeepIcon)).bindLabel('The Alchemy').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
-			// NE Velen
-				L.marker([0.09, -45.62], setMarker(innkeepIcon)).bindLabel('Inn at the Crossroads').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, and drink'),
-		]);
+	markers.innkeep = L.layerGroup([
+		// Novigrad
+			createMarker([73.24, -44.21], icons.innkeep, 'The Golden Sturgen', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
+			createMarker([78.22, -33.49], icons.innkeep, 'Passiflora', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
+			createMarker([76.20, -24.35], icons.innkeep, 'The Nowhere', '<h1>Innkeep</h1>Sells Food and drink'),
+			createMarker([70.02, -29.56], icons.innkeep, 'Rosemary &amp; Thyme', '<h1>Innkeep</h1>Sells Food and drink'),
+			createMarker([70.04, -1.85], icons.innkeep, 'Seven Cats Inn', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
+			createMarker([74.50, -32.61], icons.innkeep, 'The Kingfisher', '<h1>The Kingfisher</h1>Warning, this trader may disappear later in the game. Sells Gwent cards, food, and drink'),
+		// S Novigrad
+			createMarker([62.33, -14.02], icons.innkeep, 'Cunny of the Goose', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
+		// Oxenfurt
+			createMarker([36.46, 52.27], icons.innkeep, 'The Alchemy', '<h1>Innkeep</h1>Sells Gwent cards, food, and drink'),
+		// NE Velen
+			createMarker([0.09, -45.62], icons.innkeep, 'Inn at the Crossroads', '<h1>Innkeep</h1>Sells Gwent cards, and drink'),
+	]);
 
 	// Monster Den
-		var monsterdenIcon = L.icon({
-			iconUrl  : '/files/img/icons/monsterden.png',
-			iconSize : [30, 27]
-		});
+	var monsterdenGeneric = genericMarkers([
+		// NE Velen
+			[20.47, -13.76],
+		// SE Velen
+			[-54.47, 12.00],
+	], icons.monsterden, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby');
 
-		var monsterdenGeneric = genericMarkers([
-			// NE Velen
-				[20.47, -13.76],
-			// SE Velen
-				[-54.47, 12.00],
-		], monsterdenIcon, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby');
-
-		window.markers['monsterden'] = L.layerGroup($.merge(monsterdenGeneric, [
-			// NE Novigrad
-				L.marker([82.19, -32.08], setMarker(monsterdenIcon)).bindLabel('Monster Den').bindPopup('<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby (lvl 19<span> Golem</span>)'),
-			// S Novigrad
-				L.marker([46.99, -40.08], setMarker(monsterdenIcon)).bindLabel('Monster Den').bindPopup('<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby (lvl 16<span> Rabid Rock Troll</span> &amp; lvl 18<span> Nekkers</span>)'),
-		]));
+	markers.monsterden = L.layerGroup($.merge(monsterdenGeneric, [
+		// NE Novigrad
+			createMarker([82.19, -32.08], icons.monsterden, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby (lvl 19<span> Golem</span>)'),
+		// S Novigrad
+			createMarker([46.99, -40.08], icons.monsterden, 'Monster Den', '<h1>Monster Den</h1>Monster-infested location. A constant worry for those living nearby (lvl 16<span> Rabid Rock Troll</span> &amp; lvl 18<span> Nekkers</span>)'),
+	]));
 
 	// Monster Nest
-		var monsternestIcon = L.icon({
-			iconUrl  : '/files/img/icons/monsternest.png',
-			iconSize : [23, 30]
-		});
+	var monsternestGeneric = genericMarkers([
+		// NE Velen
+			[33.87, 10.20],
+			[41.44, -0.79],
+		// NW Velen
+			[-23.97, -55.95],
+			[-36.56, -87.14],
+			[-53.38, -57.74],
+		// SW Velen
+			[-75.14, -122.29],
+			[-74.73, -121.49],
+		// SE Velen
+			[-68.69, -2.20],
+	], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
 
-		var monsternestGeneric = genericMarkers([
-			// NE Velen
-				[33.87, 10.20],
-				[41.44, -0.79],
-			// NW Velen
-				[-23.97, -55.95],
-				[-36.56, -87.14],
-				[-53.38, -57.74],
-			// SW Velen
-				[-75.14, -122.29],
-				[-74.73, -121.49],
-			// SE Velen
-				[-68.69, -2.20],
-		], monsternestIcon, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
-
-		window.markers['monsternest'] = L.layerGroup($.merge(monsternestGeneric, [
-			// S Novigrad
-				L.marker([34.31, -60.51], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'),
-				L.marker([49.84, -45.97], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Endregas</span>)'),
-				L.marker([50.79, -42.19], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Endregas</span>)'),
-				L.marker([50.98, -20.99], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'),
-			// NE Velen
-				L.marker([7.36, 48.78], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'),
-				L.marker([8.01, 47.37], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'),
-				L.marker([-2.94, 27.38], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'),
-				L.marker([41.64, 13.97], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'),
-			// SW Velen
-				L.marker([-75.68, -27.11], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 4&amp;9<span> Drowners</span>)'),
-			// SE Velen
-				L.marker([-50.23, 57.57], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8<span> Nekkers</span>)'),
-				L.marker([-46.01, 52.56], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'),
-				L.marker([-49.04, 46.93], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'),
-				L.marker([-49.12, 42.36], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'),
-				L.marker([-40.18, 80.29], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 21<span> Wyvern</span>)'),
-				L.marker([-41.38, 80.38], setMarker(monsternestIcon)).bindLabel('Monster Nest').bindPopup('<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 21<span> Wyvern</span>)'),
-		]));
+	markers.monsternest = L.layerGroup($.merge(monsternestGeneric, [
+		// S Novigrad
+			createMarker([34.31, -60.51], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'),
+			createMarker([49.84, -45.97], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Endregas</span>)'),
+			createMarker([50.79, -42.19], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Endregas</span>)'),
+			createMarker([50.98, -20.99], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'),
+		// NE Velen
+			createMarker([7.36, 48.78], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'),
+			createMarker([8.01, 47.37], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'),
+			createMarker([-2.94, 27.38], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 9<span> Ghouls</span>)'),
+			createMarker([41.64, 13.97], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 6<span> Rotfiends</span>)'),
+		// SW Velen
+			createMarker([-75.68, -27.11], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 4&amp;9<span> Drowners</span>)'),
+		// SE Velen
+			createMarker([-50.23, 57.57], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8<span> Nekkers</span>)'),
+			createMarker([-46.01, 52.56], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'),
+			createMarker([-49.04, 46.93], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'),
+			createMarker([-49.12, 42.36], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 8/9<span> Nekkers</span>)'),
+			createMarker([-40.18, 80.29], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 21<span> Wyvern</span>)'),
+			createMarker([-41.38, 80.38], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs (lvl 21<span> Wyvern</span>)'),
+	]));
 
 	// Notice Board
-		var noticeIcon = L.icon({
-			iconUrl  : '/files/img/icons/notice.png',
-			iconSize : [23, 28]
-		});
-
-		window.markers['notice'] = L.layerGroup(genericMarkers([
-			// Novigrad
-				[74.38, -34.06],
-				[73.00, -43.37],
-				[76.74, -32.21],
-				[64.42, -38.42],
-			// NE Novigrad
-				[82.13, 3.43],
-			// E Novigrad
-				[69.60, -1.93],
-				[73.07, 42.19],
-			// S Novigrad
-				[62.59, -16.70],
-			// Oxenfurt
-				[38.89, 52.29],
-			// NE Velen
-				[4.65, -12.04],
-				[1.14, -46.41],
-				[33.36, -21.18],
-			// NW Velen
-				[-54.19, -120.50],
-				[-31.50, -69.08],
-				[-63.51, -73.74],
-			// SE Velen
-				[-58.08, 27.95],
-				[-36.17, -26.02],
-				[-78.73, 110.17],
-		], noticeIcon, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
+	markers.notice = L.layerGroup(genericMarkers([
+		// Novigrad
+			[74.38, -34.06],
+			[73.00, -43.37],
+			[76.74, -32.21],
+			[64.42, -38.42],
+		// NE Novigrad
+			[82.13, 3.43],
+		// E Novigrad
+			[69.60, -1.93],
+			[73.07, 42.19],
+		// S Novigrad
+			[62.59, -16.70],
+		// Oxenfurt
+			[38.89, 52.29],
+		// NE Velen
+			[4.65, -12.04],
+			[1.14, -46.41],
+			[33.36, -21.18],
+		// NW Velen
+			[-54.19, -120.50],
+			[-31.50, -69.08],
+			[-63.51, -73.74],
+		// SE Velen
+			[-58.08, 27.95],
+			[-36.17, -26.02],
+			[-78.73, 110.17],
+	], icons.notice, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
 
 	// Person in Distress
-		var pidIcon = L.icon({
-			iconUrl  : '/files/img/icons/pid.png',
-			iconSize : [24, 34]
-		});
+	var pidGeneric = genericMarkers([
+		// NE Velen
+			[26.43, -11.87],
+		// NW Velen
+			[-33.94, -132.36],
+	], icons.pid, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance');
 
-		var pidGeneric = genericMarkers([
-			// NE Velen
-				[26.43, -11.87],
-			// NW Velen
-				[-33.94, -132.36],
-		], pidIcon, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance');
-
-		window.markers['pid'] = L.layerGroup($.merge(pidGeneric, [
-			// SE Novigrad
-				L.marker([20.47, 100.55], setMarker(pidIcon)).bindLabel('Person(s) in Distress').bindPopup('<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance (lvl 9<span> Bandits</span>)'),
-			// NE Velen
-				L.marker([-17.64, -29.18], setMarker(pidIcon)).bindLabel('Person(s) in Distress').bindPopup('<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance (lvl 10-16<span> Bandits</span>)'),
-			// NW Velen
-				L.marker([-61.23, -33.93], setMarker(pidIcon)).bindLabel('Person(s) in Distress').bindPopup('<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance (lvl 5<span> Bandits</span>)'),
-		]));
+	markers.pid = L.layerGroup($.merge(pidGeneric, [
+		// SE Novigrad
+			createMarker([20.47, 100.55], icons.pid, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance (lvl 9<span> Bandits</span>)'),
+		// NE Velen
+			createMarker([-17.64, -29.18], icons.pid, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance (lvl 10-16<span> Bandits</span>)'),
+		// NW Velen
+			createMarker([-61.23, -33.93], icons.pid, 'Person(s) in Distress', '<h1>Person(s) in Distress</h1>There\'s a person or a group of people here in need of assitance (lvl 5<span> Bandits</span>)'),
+	]));
 
 	// Place of Power
-		var popIcon = L.icon({
-			iconUrl  : '/files/img/icons/pop.png',
-			iconSize : [27, 30]
-		});
-
-		//todo get all place of power types
-		window.markers['pop'] = L.layerGroup([
-			// Novigrad
-				L.marker([80.72, -40.83], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Igni</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			// E Novigrad
-				L.marker([71.02, 48.78], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Axii</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			// NW Velen
-				L.marker([32.69, -112.60], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			// SW Velen
-				L.marker([-82.85, -72.69], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Aard</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-				L.marker([-71.82, -105.91], setMarker(popIcon)).bindLabel('Place of Power*').bindPopup('<h1>Place of Power - Yrden</h1>\'Wandering in the Dark\' quest. Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			// SE Velen
-				L.marker([-78.19, 7.91], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-				L.marker([-70.41, 38.41], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-				L.marker([-55.68, 18.94], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-				
-		]);
+	//todo get all place of power types
+	markers.pop = L.layerGroup([
+		// Novigrad
+			createMarker([80.72, -40.83], icons.pop, 'Place of Power', '<h1>Place of Power - Igni</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+		// E Novigrad
+			createMarker([71.02, 48.78], icons.pop, 'Place of Power', '<h1>Place of Power - Axii</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+		// NW Velen
+			createMarker([32.69, -112.60], icons.pop, 'Place of Power', '<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+		// SW Velen
+			createMarker([-82.85, -72.69], icons.pop, 'Place of Power', '<h1>Place of Power - Aard</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+			createMarker([-71.82, -105.91], icons.pop, 'Place of Power*', '<h1>Place of Power - Yrden</h1>\'Wandering in the Dark\' quest. Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+		// SE Velen
+			createMarker([-78.19, 7.91], icons.pop, 'Place of Power', '<h1>Place of Power - todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+			createMarker([-70.41, 38.41], icons.pop, 'Place of Power', '<h1>Place of Power - todo</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+			createMarker([-55.68, 18.94], icons.pop, 'Place of Power', '<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+			
+	]);
 
 	// Point of Interest
-		var poiIcon = L.icon({
-			iconUrl  : '/files/img/icons/poi.png',
-			iconSize : [28, 28]
-		});
-
-		window.markers['poi'] = L.layerGroup([
-			// Novigrad
-				L.marker([74.84, -25.88], setMarker(poiIcon)).bindLabel('Triss\' Residence').bindPopup('<h1>Triss\' Residence</h1>todo'),
-				L.marker([70.12, -28.76], setMarker(poiIcon)).bindLabel('Dandelion &amp; Zoltan\'s Residence').bindPopup('<h1>Dandelion &amp; Zoltan\'s Residence</h1>todo'),
-				L.marker([77.245, -24.829], setMarker(poiIcon)).bindLabel('Vilmerius Hospital').bindPopup('<h1>Vilmerius Hospital</h1>todo'),
-			// NW Velen
-				L.marker([-47.34, -111.81], setMarker(poiIcon)).bindLabel('Keira Metz\'s Residence').bindPopup('<h1>Keira Metz\'s Residence</h1>todo'),
-			// Velen
-				L.marker([61.90, -91.82], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Feline Crossbow</h1>'),
-				L.marker([57.651, -30.169], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Superior Feline Silver Sword</h1>'),
-				L.marker([75.70, -19.50], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Enhanced Feline Silver Sword</h1>You need to climp up a Leader'),
-				L.marker([60.60, 89.80], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Feline Silver Sword</h1>Inside the Est Tayiar Ruine, behind a Wall that you can break'),
-				L.marker([36.50, 114,50], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Enhanced Feline Armor</h1>on top of the Aeramas’ Abandoned Manor'),
-				L.marker([33, -114.5], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Griffin Silver Sword Diagram</h1>'),
-				L.marker([29.373, -73], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Enhanced Griffin Boots</h1>'),
-				L.marker([41, -1], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Griffin Steel Sword</h1>Near the Monster Nest'),
-				L.marker([36.5, 35], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Enhance Griffin Armor </h1> Near the Troll at White Eagle Fort'),
-				L.marker([22, 9.5], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Enhance Feline Gauntlets </h1>Inside a Shaft from the Codgers Quarry'),
-				L.marker([-28, -61], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Enhanced Griffin Trousers </h1>Inside the Burned Ruin'),
-				L.marker([-57, -156], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Enhanced Griffin Steel Sword </h1>'),
-				L.marker([-61, -8.5], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Superior Feline Armor</h1>'),
-				L.marker([-54.5, 12], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Griffin Armor Set</h1>Inside the Dragonslayers Grotto'),
-				L.marker([-64, 38], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Superior Ursine Steel Sword</h1>Guarded by lvl 25<span> Earth Elemental</span>'),
-				L.marker([-81.1, 30.8], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Mastercrafted Ursine Armor</h1>'),
-				L.marker([-75.6, -28], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Mastercrafted Ursine Silver Sword </h1>'),
-				L.marker([-81.2, -70], setMarker(poiIcon)).bindLabel('Witcher Upgrade Gear').bindPopup('<h1>Enhanced Griffin Gauntlets</h1>'),
-		]);
+	markers.poi = L.layerGroup([
+		// Novigrad
+			createMarker([74.84, -25.88], icons.poi, 'Triss\' Residence', '<h1>Triss\' Residence</h1>todo'),
+			createMarker([70.12, -28.76], icons.poi, 'Dandelion &amp; Zoltan\'s Residence', '<h1>Dandelion &amp; Zoltan\'s Residence</h1>todo'),
+			createMarker([77.245, -24.829], icons.poi, 'Vilmerius Hospital', '<h1>Vilmerius Hospital</h1>todo'),
+		// NW Velen
+			createMarker([-47.34, -111.81], icons.poi, 'Keira Metz\'s Residence', '<h1>Keira Metz\'s Residence</h1>todo'),
+		// Velen
+			createMarker([61.90, -91.82], icons.poi, 'Witcher Upgrade Gear', '<h1>Feline Crossbow</h1>'),
+			createMarker([57.651, -30.169], icons.poi, 'Witcher Upgrade Gear', '<h1>Superior Feline Silver Sword</h1>'),
+			createMarker([75.70, -19.50], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Feline Silver Sword</h1>You need to climp up a Leader'),
+			createMarker([60.60, 89.80], icons.poi, 'Witcher Upgrade Gear', '<h1>Feline Silver Sword</h1>Inside the Est Tayiar Ruine, behind a Wall that you can break'),
+			createMarker([36.50, 114,50], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Feline Armor</h1>on top of the Aeramas’ Abandoned Manor'),
+			createMarker([33, -114.5], icons.poi, 'Witcher Upgrade Gear', '<h1>Griffin Silver Sword Diagram</h1>'),
+			createMarker([29.373, -73], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Griffin Boots</h1>'),
+			createMarker([41, -1], icons.poi, 'Witcher Upgrade Gear', '<h1>Griffin Steel Sword</h1>Near the Monster Nest'),
+			createMarker([36.5, 35], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhance Griffin Armor </h1> Near the Troll at White Eagle Fort'),
+			createMarker([22, 9.5], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhance Feline Gauntlets </h1>Inside a Shaft from the Codgers Quarry'),
+			createMarker([-28, -61], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Griffin Trousers </h1>Inside the Burned Ruin'),
+			createMarker([-57, -156], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Griffin Steel Sword </h1>'),
+			createMarker([-61, -8.5], icons.poi, 'Witcher Upgrade Gear', '<h1>Superior Feline Armor</h1>'),
+			createMarker([-54.5, 12], icons.poi, 'Witcher Upgrade Gear', '<h1>Griffin Armor Set</h1>Inside the Dragonslayers Grotto'),
+			createMarker([-64, 38], icons.poi, 'Witcher Upgrade Gear', '<h1>Superior Ursine Steel Sword</h1>Guarded by lvl 25<span> Earth Elemental</span>'),
+			createMarker([-81.1, 30.8], icons.poi, 'Witcher Upgrade Gear', '<h1>Mastercrafted Ursine Armor</h1>'),
+			createMarker([-75.6, -28], icons.poi, 'Witcher Upgrade Gear', '<h1>Mastercrafted Ursine Silver Sword </h1>'),
+			createMarker([-81.2, -70], icons.poi, 'Witcher Upgrade Gear', '<h1>Enhanced Griffin Gauntlets</h1>'),
+	]);
 
 	// Shopkeeper
-		var shopkeeperIcon = L.icon({
-			iconUrl  : '/files/img/icons/merchant.png',
-			iconSize : [21, 30]
-		});
-
-		window.markers['shopkeeper'] = L.layerGroup([
-			// Novigrad
-				L.marker([74.22, -35.41], setMarker(shopkeeperIcon)).bindLabel('Book Merchant').bindPopup('<h1>Book Merchant</h1>Buys and sells books'),
-				L.marker([74.578, -35.332], setMarker(shopkeeperIcon)).bindLabel('Book Merchant').bindPopup('<h1>Book Merchant</h1>Buys and sells books'),
-				L.marker([72.82, -39.99], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells alchemy supplies, food, and drink'),
-				L.marker([73.71, -37.96], setMarker(shopkeeperIcon)).bindLabel('Banker').bindPopup('<h1>Banker</h1>You can exchange your unusable currency or borrow gold here'),
-				L.marker([69.90, -20.47], setMarker(shopkeeperIcon)).bindLabel('Clothing Merchant').bindPopup('<h1>Clothing Merchant</h1>Sells clothes and masks'),
-				L.marker([70.05, -37.13], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells crafting supplies, weapons and \'Zerrikanian Saddlebags\' (+100)'),
-				L.marker([76.81, -33.26], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells alchemy supplies, quest items (for Aeramas\' Manor), and \'Potion of Clearance\' (1000 gold)'),
-				L.marker([75.41, -44.82], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells alchemy supplies, food, and drink'),
-				L.marker([74.47, -46.93], setMarker(shopkeeperIcon)).bindLabel('Fishmonger').bindPopup('<h1>Fishmonger</h1>Sells fish'),
-				L.marker([76.57, -50.10], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells empty bottles'),
-				L.marker([76.12, -49.04], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells runestones and alchemy supplies'),
-				L.marker([74.98, -20.57], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells nothing note worthy'),
-				L.marker([72.58, -26.41], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells gem dust (crafting supplies), weapons, food, and drink'),
-				L.marker([75.33, -19.28], setMarker(shopkeeperIcon)).bindLabel('Loan Shark').bindPopup('<h1>Loan Shark</h1>Sells nothing note worthy'),
-				L.marker([75.61, -23.82], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells crafting supplies'),
-				L.marker([71.00, -41.60], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells food and drink'),
-			// NE Novigrad
-				L.marker([80.92, 50.49], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
-			// SE Novigrad
-				L.marker([3.43, 97.08], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>This merchant appears here after being rescued'),
-			// S Novigrad
-// appears on my map but nobody there?
-//				L.marker([65.95, -21.09], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper'),
-				L.marker([58.677, -55.415], setMarker(shopkeeperIcon)).bindLabel('Wandering Merchant').bindPopup('<h1>Wandering Merchant</h1>Traveling from Lucian\'s Windmill to the Portside Gate. Sells runestones, alchemy supplies and food'),
-				L.marker([63.27, -63.46], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells crafting supplies, food, and weapons'),
-				L.marker([48.72, -51.94], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
-				L.marker([57.98, -12.00], setMarker(shopkeeperIcon)).bindLabel('Wandering Merchant').bindPopup('<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
-			// Oxenfurt
-				L.marker([40.01, 51.48], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells paint (quest item), hides, and drink'),
-			// NE Velen
-				L.marker([26.00, 30.11], setMarker(shopkeeperIcon)).bindLabel('Wandering Merchant').bindPopup('<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
-				L.marker([31.65, -17.93], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>This merchant appears here after being rescued. Sells alchemy supplies and food'),
-				L.marker([-6.84, 72.38], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells weapons and crafting supplies'),
-				L.marker([13.07, 46.27], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells runestones, alchemy supplies and food'),
-			// NW Velen
-				L.marker([-27.84, -102.74], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells nothing note worthy'),
-				L.marker([-34.96, -72.77], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells Gwent cards and drink'),
-				L.marker([-54.42, -121.65], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells Gwent cards and jewellery (crafting supplies)'),
-				L.marker([-47.04, -112.50], setMarker(shopkeeperIcon)).bindLabel('Keira Metz').bindPopup('<h1>Keira Metz</h1>Sells alchemy supplies, recipes and \'Potion of Clearance\' (1000 gold)'),
-				L.marker([-32.03, -71.77], setMarker(shopkeeperIcon)).bindLabel('Quartermaster').bindPopup('<h1>Quartermaster</h1>Sells Gwent cards, food, and drink'),
-				L.marker([-36.10, -72.51], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper Anselm').bindPopup('<h1>Shopkeeper Anselm</h1>This merchant appears here after being rescued. Sells \'Racing Horse Blinders\' (+40)'),
-				L.marker([-62.57, -76.89], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells drink and \'Rugged Saddlebags\' (+70)'),
-				L.marker([-52.70, -81.49], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells Gwent cards and drink'),
-				L.marker([-52.96, -56.65], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells runestones and alchemy supplies'),
-				L.marker([-45.09, -138.96], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
-				L.marker([-58.36, -142.91], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
-			// SW Velen
-				L.marker([-79.58, -114.12], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells runestones, alchemy supplies and food'),
-			// SE Velen
-				L.marker([-36.17, 3.69], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>This merchant appears here after being rescued. Sells alchemy supplies and food'),
-				L.marker([-36.88, -24.35], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells Gwent cards, and crafting supplies'),
-				L.marker([-37.79, -26.19], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
-				L.marker([-78.79, 108.24], setMarker(shopkeeperIcon)).bindLabel('Quartermaster').bindPopup('<h1>Quartermaster</h1>Sells nothing note worthy'),
-				L.marker([-57.35, 27.03], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>This merchant disappears sometime after the \'Family matters\' quest. Sells drink'),
-				L.marker([-76.16, 107.67], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells runestones and alchemy supplies'),
-				L.marker([-75.93, 110.28], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
-				L.marker([-75.50, 110.81], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells weapons and crafting supplies'),
-			
-		]);
+	markers.shopkeeper = L.layerGroup([
+		// Novigrad
+			createMarker([74.22, -35.41], icons.shopkeeper, 'Book Merchant', '<h1>Book Merchant</h1>Buys and sells books'),
+			createMarker([74.578, -35.332], icons.shopkeeper, 'Book Merchant', '<h1>Book Merchant</h1>Buys and sells books'),
+			createMarker([72.82, -39.99], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells alchemy supplies, food, and drink'),
+			createMarker([73.71, -37.96], icons.shopkeeper, 'Banker', '<h1>Banker</h1>You can exchange your unusable currency or borrow gold here'),
+			createMarker([69.90, -20.47], icons.shopkeeper, 'Clothing Merchant', '<h1>Clothing Merchant</h1>Sells clothes and masks'),
+			createMarker([70.05, -37.13], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies, weapons and \'Zerrikanian Saddlebags\' (+100)'),
+			createMarker([76.81, -33.26], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells alchemy supplies, quest items (for Aeramas\' Manor), and \'Potion of Clearance\' (1000 gold)'),
+			createMarker([75.41, -44.82], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells alchemy supplies, food, and drink'),
+			createMarker([74.47, -46.93], icons.shopkeeper, 'Fishmonger', '<h1>Fishmonger</h1>Sells fish'),
+			createMarker([76.57, -50.10], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells empty bottles'),
+			createMarker([76.12, -49.04], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones and alchemy supplies'),
+			createMarker([74.98, -20.57], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells nothing note worthy'),
+			createMarker([72.58, -26.41], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells gem dust (crafting supplies), weapons, food, and drink'),
+			createMarker([75.33, -19.28], icons.shopkeeper, 'Loan Shark', '<h1>Loan Shark</h1>Sells nothing note worthy'),
+			createMarker([75.61, -23.82], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies'),
+			createMarker([71.00, -41.60], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells food and drink'),
+		// NE Novigrad
+			createMarker([80.92, 50.49], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
+		// SE Novigrad
+			createMarker([3.43, 97.08], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears here after being rescued'),
+		// S Novigrad
+	// appears on my map but nobody there?
+	//				L.marker([65.95, -21.09], setMarker(icons.shopkeeper)).bindLabel('Shopkeeper'),
+			createMarker([58.677, -55.415], icons.shopkeeper, 'Wandering Merchant', '<h1>Wandering Merchant</h1>Traveling from Lucian\'s Windmill to the Portside Gate. Sells runestones, alchemy supplies and food'),
+			createMarker([63.27, -63.46], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells crafting supplies, food, and weapons'),
+			createMarker([48.72, -51.94], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
+			createMarker([57.98, -12.00], icons.shopkeeper, 'Wandering Merchant', '<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
+		// Oxenfurt
+			createMarker([40.01, 51.48], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells paint (quest item), hides, and drink'),
+		// NE Velen
+			createMarker([26.00, 30.11], icons.shopkeeper, 'Wandering Merchant', '<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
+			createMarker([31.65, -17.93], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears here after being rescued. Sells alchemy supplies and food'),
+			createMarker([-6.84, 72.38], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells weapons and crafting supplies'),
+			createMarker([13.07, 46.27], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells runestones, alchemy supplies and food'),
+		// NW Velen
+			createMarker([-27.84, -102.74], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells nothing note worthy'),
+			createMarker([-34.96, -72.77], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells Gwent cards and drink'),
+			createMarker([-54.42, -121.65], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells Gwent cards and jewellery (crafting supplies)'),
+			createMarker([-47.04, -112.50], icons.shopkeeper, 'Keira Metz', '<h1>Keira Metz</h1>Sells alchemy supplies, recipes and \'Potion of Clearance\' (1000 gold)'),
+			createMarker([-32.03, -71.77], icons.shopkeeper, 'Quartermaster', '<h1>Quartermaster</h1>Sells Gwent cards, food, and drink'),
+			createMarker([-36.10, -72.51], icons.shopkeeper, 'Shopkeeper Anselm', '<h1>Shopkeeper Anselm</h1>This merchant appears here after being rescued. Sells \'Racing Horse Blinders\' (+40)'),
+			createMarker([-62.57, -76.89], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells drink and \'Rugged Saddlebags\' (+70)'),
+			createMarker([-52.70, -81.49], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells Gwent cards and drink'),
+			createMarker([-52.96, -56.65], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones and alchemy supplies'),
+			createMarker([-45.09, -138.96], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
+			createMarker([-58.36, -142.91], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
+		// SW Velen
+			createMarker([-79.58, -114.12], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears after liberating the area. Sells runestones, alchemy supplies and food'),
+		// SE Velen
+			createMarker([-36.17, 3.69], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant appears here after being rescued. Sells alchemy supplies and food'),
+			createMarker([-36.88, -24.35], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells Gwent cards, and crafting supplies'),
+			createMarker([-37.79, -26.19], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
+			createMarker([-78.79, 108.24], icons.shopkeeper, 'Quartermaster', '<h1>Quartermaster</h1>Sells nothing note worthy'),
+			createMarker([-57.35, 27.03], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>This merchant disappears sometime after the \'Family matters\' quest. Sells drink'),
+			createMarker([-76.16, 107.67], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones and alchemy supplies'),
+			createMarker([-75.93, 110.28], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells armour and crafting supplies'),
+			createMarker([-75.50, 110.81], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells weapons and crafting supplies'),
+		
+	]);
 
 	// Sign Post
-		var signpostIcon = L.icon({
-			iconUrl  : '/files/img/icons/fasttravel.png',
-			iconSize : [27, 34]
-		});
-
-		window.markers['signpost'] = L.layerGroup([
-			// Novigrad
-				L.marker([73.76, -33.97], setMarker(signpostIcon)).bindLabel('Hierarch Square').bindPopup('<h1>Hierarch Square</h1>Until quite recently a great many mages lived near Novigrad\'s main square. They fled when the witch hunters began their reign of terror, leaving many of the city\'s most beautiful townhouses abandoned and uncared for'),
-				L.marker([74.23, -15.86], setMarker(signpostIcon)).bindLabel('Southern Gate').bindPopup('<h1>Southern Gate</h1>In truth demarcating the eastern and not southern edge of the city, the Southern Gate was given its inappropriate name by a one-time city planner who knew nothing about architecture and could not read a map, but had in his favor the fact that he was the mayor\'s cousin and thew lavish parties. Though confusingly incorrect, the name stuck and now the city\'s residents never think twice about its illogical appellation'),
-				L.marker([76.44, -16.20], setMarker(signpostIcon)).bindLabel('Oxenfurt Gate').bindPopup('<h1>Oxenfurt Gate</h1>In the times when Novigrad and Oxenfurt were embroiled in fierce neighborly disputes, this gate went through several completely different names, the Gate of Harlots and the Gate of Bloodsuckers being two of the longer lived examples. Its current name was chosen when this conflict was finally put to rest'),
-				L.marker([77.64, -36.47], setMarker(signpostIcon)).bindLabel('St. Gregory\'s Bridge').bindPopup('<h1>St. Gregory\'s Bridge</h1>Bridge named after the hero of Novigrad who saved the city from a horrible famine three hundred years ago by sacrificing half his fortune to import food from Nazair. After this, he was declared a saint, something even the jurors of the Church of the Eternal Fire were unable to change'),
-				L.marker([79.73, -51.24], setMarker(signpostIcon)).bindLabel('Electors\' Square').bindPopup('<h1>Electors\' Square</h1>Square named after a group of Novigrad reformers who enacted bold transformations that led to the city\'s rapid growth, enriching its residents considerably and ushering in the city\'s golden age'),
-				L.marker([71.16, -22.94], setMarker(signpostIcon)).bindLabel('Tretogor Gate').bindPopup('<h1>Tretogor Gate</h1>Gate erected with funds from the Redanian royal family, who, wanting to earn favor with Novigrad merchants and the hierach, dedicated a significant amount of coin to its construction, as well as some no-less-valuable (wo)manpower in the form of the master architect Countess Anna Yaye-Pinkovitz and her skilled crew'),
-				L.marker([68.94, -27.77], setMarker(signpostIcon)).bindLabel('Gate of the Hierarch').bindPopup('<h1>Gate of the Hierarch</h1>This gate is named in honor of Novigrad\'s own son, the Hierach of the eternal Fire. Supposedly this name was given to it upon popular request, though no one can be found who remembers requesting any such thing'),
-				L.marker([66.32, -35.31], setMarker(signpostIcon)).bindLabel('Glory Gate').bindPopup('<h1>Glory Gate</h1>Toughs and hooligans often end a night of drunken escapades under this gate after being thrown out of the nearby taverns'),
-				L.marker([65.99, -43.90], setMarker(signpostIcon)).bindLabel('Portside Gate').bindPopup('<h1>Portside Gate</h1>Though not the most stately of gates, this one\'s location near the bustling port has made it the calling card of the city'),
-				L.marker([69.57, -55.28], setMarker(signpostIcon)).bindLabel('Novigrad Docks').bindPopup('<h1>Novigrad Docks</h1>A den of dirt and depravity and the shadiest part of Novigrad. After dark all one finds here are women of loose morals, hoodlums and drunk sailors'),
-				L.marker([75.39, -8.88], setMarker(signpostIcon)).bindLabel('Arette').bindPopup('<h1>Arette</h1>Novigrad has always attracted those in search of a better life. Some of them found no welcome within the city walls, and so built huts outside the city'),
-				L.marker([69.57, -2.81], setMarker(signpostIcon)).bindLabel('Seven Cats Inn').bindPopup('<h1>Seven Cats Inn</h1>This dank establishment is host to a shady clientele'),
-			// NE Novigrad
-				L.marker([83.53, -9.40], setMarker(signpostIcon)).bindLabel('Sarrasin Grange').bindPopup('<h1>Sarrasin Grange</h1>Lord Antares Sarrasin moved his wife and smattering of comely daughters here from far-off Nazair on his medic\'s recommendations. The leech proclaimed with absolute certainy that "if you wish to sire a son, it must be in the Gustfields." While waiting to produce a male heir, the Sarrasins took to wine cultivation and soon their grange became renowned from Nazair to Skellige'),
-				L.marker([81.92, 3.60], setMarker(signpostIcon)).bindLabel('Yantra').bindPopup('<h1>Yantra</h1>The inhabitants of this village are known for their talkativeness and tendency to exagerrate, which makes them good companions for a round of drink, but impossible to tolerate for long stretches of time'),
-				L.marker([82.09, 30.15], setMarker(signpostIcon)).bindLabel('Isolated Hut').bindPopup('<h1>Isolated Hut</h1>Rumors claim a famous painter lives in this house, though no one has ever seen him or knows his name'),
-				L.marker([76.24, 18.26], setMarker(signpostIcon)).bindLabel('Honeyfill Meadworks').bindPopup('<h1>Honeyfill Meadworks</h1>The renowned Honeyfill Meadworks has for generations belonged to a respected family of halflings'),
-				L.marker([79.04, 65.21], setMarker(signpostIcon)).bindLabel('Martin Feuille\'s Farmstead').bindPopup('<h1>Martin Feuille\'s Farmstead</h1>Founded by Lord Martin Feuille, this vast plantation was until not so long ago the largest producer of alfalfa in the region. Sadly, when war broke out the lord fled to his winter residence in Kovir, leaving his land to be administered by an ill-suited stward who squandered his liege\'s fertile fields'),
-				L.marker([81.02, 49.09], setMarker(signpostIcon)).bindLabel('Winespring Grange').bindPopup('<h1>Winespring Grange</h1>Years ago, an eccentric count named Jacobus Ruth of the Rieslings settled here. The count could not stand the pomposity of court life but loved good wine. He thus planted a vineyard here which produces a fabulous beaujolais prized on both sides of the Pontar'),
-				L.marker([79.59, 31.03], setMarker(signpostIcon)).bindLabel('Moldavie Residence').bindPopup('<h1>Moldavie Residence</h1>Despite its ideal location and beautiful surroundings, this residence has been tossed from owner to owner like a hot potato, and for some unknown reason suffers from a bad reputation'),
-				L.marker([81.66, -31.55], setMarker(signpostIcon)).bindLabel('Cavern').bindPopup('<h1>Cavern</h1>One of those places wise men avoid at all costs, so as not to tempt fate'),
-			// E Novigrad
-				L.marker([72.92, 41.31], setMarker(signpostIcon)).bindLabel('Alness').bindPopup('<h1>Alness</h1>Until recently, this was a thoroughly unremarkable village. then the Vegelbuds began organizing their famous horse races here, granting Alness the enviable honor of hosting the region\'s most pretigious equestrian contests'),
-				L.marker([67.58, 31.03], setMarker(signpostIcon)).bindLabel('Wheat Fields').bindPopup('<h1>Wheat Fields</h1>The fertile soils of the Pontar delta guarantee the inhabitants of Novigrad full granaries and full stomaches all year long'),
-				L.marker([65.31, 46.67], setMarker(signpostIcon)).bindLabel('Vegelbud Residence').bindPopup('<h1>Vegelbud Residence</h1>Domicile of a prominent Novigrad family whose line can be traced back to the times when the first human settlers came to these lands'),
-			// SE Novigrad
-				L.marker([62.02, 39.11], setMarker(signpostIcon)).bindLabel('Carsten').bindPopup('<h1>Carsten</h1>A village named after a baker whose exquisite goods gained him fame, as well as the privilege of supplying bread to the table of the hierarch of the Church of the Eternal Fire in Novigrad. Following his death, none proved capable of recreating his recipes for his delicious and depply aromatic breads, so these days Carsten is known chiefly for its trade in grain and flour'),
-				L.marker([58.56, 66.27], setMarker(signpostIcon)).bindLabel('Temerian Partisan Hideout').bindPopup('<h1>Temerian Partisan Hideout</h1>Though the Nilfgaardians thought Temeria died along with King Foltest, Temerian guerillas still hide in the woods, prepared to give their lives at a moment\'s notice in their fight for independence'),
-				L.marker([59.82, 85.87], setMarker(signpostIcon)).bindLabel('Est Tayiar').bindPopup('<h1>Est Tayiar</h1>Long before men first peopled these lands, a beautiful, prospering elven city stood here, centered around the palace of King Maeglor. One day, however, the city\'s inhabitants began mysteriously dying off in large numbers. According to legend, King Maeglor sensed he, too, would soon perish and cast a powerful spell that caused the earth to swallow the city whole so that no outsider could ever desecrate it. Centuries later, scholars from the Oxenfurt Academy began painstaking excavations of King Maeglor\'s palace in a search for the causes of the catastrophe. Yet work came to a sudden halt when three subsequent expeditions ventured into the ruins\' depths - and were never heard from again...'),
-				L.marker([49.45, 70.67], setMarker(signpostIcon)).bindLabel('Herbalist\'s Hut').bindPopup('<h1>Herbalist\'s Hut</h1>Home to a halfling herbalist who is a passionate devotee of innovative gardening methods and experimental herbal medicine'),
-				L.marker([35.51, 110.67], setMarker(signpostIcon)).bindLabel('Aeramas\' Abandoned Manor').bindPopup('<h1>Aeramas\' Abandoned Manor</h1>Peasants living nearby often complain about the overwhelming cheese stench wafting out of this residence...'),
-				L.marker([19.89, 83.06], setMarker(signpostIcon)).bindLabel('Crossroads').bindPopup('<h1>Crossroads</h1>A small crossroads in the woods'),
-				L.marker([49.85, 52.73], setMarker(signpostIcon)).bindLabel('Gustfields Farm').bindPopup('<h1>Gustfields Farm</h1>Farmstead founded years ago by an eccentric flaxen-haired painter named Cunigund de Cabbrae, who came here seeking peace, quiet and fresh country air'),
-				L.marker([76.64, 37.00], setMarker(signpostIcon)).bindLabel('Dancing Windmill').bindPopup('<h1>Dancing Windmill</h1>When the current owner\'s grandfather, the famous dancer Pablo "Sugar" Sasko, ended his career, he settled here and organised nights of dancing for the nearby peasantry. Supposedly these revelries became so fashionable that dung-booted peasants were dancing rounds with members of Novigrad\'s most elite familes and adventure-seeking urban dandies'),
-			// S Novigrad
-				L.marker([67.20, -65.48], setMarker(signpostIcon)).bindLabel('Loggers Hut').bindPopup('<h1>Loggers Hut</h1>A lone cabin deep in the Novigrad Forest - an ideal base for woodcutters'),
-				L.marker([66.92, -85.25], setMarker(signpostIcon)).bindLabel('Lighthouse').bindPopup('<h1>Lighthouse</h1>Many years ago a horrible accident took place here: a ship carrying the cousin of King Radovid IV the Bald wrecked against the rocks during a storm. The king ordered a lighthouse erected on that spot in order to warn other seafarers of its deadly danger'),
-				L.marker([61.90, -14.08], setMarker(signpostIcon)).bindLabel('Cunny of the Goose').bindPopup('<h1>Cunny of the Goose</h1>This inn owes its name to its former owner, a swaggering, blustering fellow who wanted to attract those of a similar temperatment. Luckily he died of liver poisoning after a few years and ownership passed to a distant relative, who turned the Cunny of the Goose into the best spot for stuffed goose liver in all the region'),
-				L.marker([58.03, -29.44], setMarker(signpostIcon)).bindLabel('Drahim Castle').bindPopup('<h1>Drahim Castle</h1>In its glory years, this castle was home to the Redanian Moskovitz of the Sea Cats dynasty, patrons of the arts and admirers of elven culture. After the death by suicide of the dynasty\'s last member, Prince Adrien, the castle fell into the hands of the Redanian crown - and then into ruin'),
-				L.marker([54.10, -71.98], setMarker(signpostIcon)).bindLabel('Widows\' Grotto').bindPopup('<h1>Widows\' Grotto</h1>According to legend, many years ago a young woman would wait here and watch for her husband\'s return from an overseas raid. Years passed and the woman grew old, still waiting for her husband. Yet he never came, and finally, she died. Three days after her funeral, her husband returned, having at last escaped from the pirates who had held him captive all that time. When he learned about his beloved\'s loyal vigil, he wept bitter tears, then lept to his death'),
-				L.marker([45.98, -51.33], setMarker(signpostIcon)).bindLabel('Ursten').bindPopup('<h1>Ursten</h1>War has caused countless refugees to flee Temeria. With the Pontar blockaded, they have tended to flood villages which, like Ursten, are located close to river crossings'),
-				L.marker([60.50, -55.55], setMarker(signpostIcon)).bindLabel('Lucian\'s Windmill').bindPopup('<h1>Lucian\'s Windmill</h1>Lucian le Foix, the famous Oxenfurt sculptor and architect, bought this windmill several years ago and made it into his country retreat. Sadly the enormous popularity of the great Lucian\'s designs means he spends little time in his fortress of solitude and has entrusted its care to a steward'),
-				L.marker([62.35, 11.69], setMarker(signpostIcon)).bindLabel('Eternal Fire Chapel').bindPopup('<h1>Eternal Fire Chapel</h1>This shrine greets travelers on their way to Oxenfurt. Merchants sometimes stop here to sell goods to pilgrims and visiting scholars'),
-				L.marker([37.11, -27.23], setMarker(signpostIcon)).bindLabel('Border Post').bindPopup('<h1>Border Post</h1>A small isle stuck in the river\'s central current - an ideal place for bleaching cloth'),
-			// Oxenfurt
-				L.marker([38.17, 62.31], setMarker(signpostIcon)).bindLabel('Novigrad Gate').bindPopup('<h1>Novigrad Gate</h1>During Oxenfurt Academy\'s exam sessions, this gate would be closed, to spare the students from Novigrad\'s temptations'),
-				L.marker([29.10, 52.58], setMarker(signpostIcon)).bindLabel('Western Gate').bindPopup('<h1>Western Gate</h1>Before war broke out, several hundred people a day would pass through here. Now the Redanian blockade has slowed traffic to a mere trickle'),
-				L.marker([37.40, 48.34], setMarker(signpostIcon)).bindLabel('Oxenfurt Harbor').bindPopup('<h1>Oxenfurt Harbor</h1>Oxenfurt\'s picturesque port has featured as the subject of numerous odes and ballads, the setting for at least three lurid crime novels, and a favorite spot for romantic outings for generations of students'),
-			// NE Velen
-				L.marker([15.62, 25.66], setMarker(signpostIcon)).bindLabel('Stonecutters\' Settlement').bindPopup('<h1>Stonecutters\' Settlement</h1>Over Twenty years ago a certain Bartolomeo, known as "Badger" on account of certain characteristic aspects of his coiffure, discovered a rich deposit of high-quality stone on this spot. He bought the land for a song, then leased it back to local peasants before heading off to Kovir, where he lives the life of a rich and powerful townsman to this day'),
-				L.marker([35.96, 34.41], setMarker(signpostIcon)).bindLabel('White Eagle Fort').bindPopup('<h1>White Eagle Fort</h1>The grand name might seem in ill-fitting with this place, but the troll that lives here - a Redanian patriot and military aficionado - goes to great lengths to make his beloved King Radovid proud'),
-				L.marker([27.45, 12.00], setMarker(signpostIcon)).bindLabel('Codgers\' Quarry').bindPopup('<h1>Codgers\' Quarry</h1>The now-inactive quarry once only employed stonebreakers over thirty years of age who would work hard all day, then spend the evenings racing down the sides of the quarry pit on hand-crafted wagons'),
-				L.marker([39.61, -2.42], setMarker(signpostIcon)).bindLabel('Hindhold').bindPopup('<h1>Hindhold</h1>This watchtower used to protect barges traveling between Oxenfurt and Novigrad. It once even boasted a bridge connecting the two sides of the river, but now it stands abandoned and neglected, its bridge a collapsed ruin'),
-				L.marker([-4.01, 63.37], setMarker(signpostIcon)).bindLabel('Ferry Station').bindPopup('<h1>Ferry Station</h1>The ferry\'s former owners were famed for treating travelers who were forced to wait for better conditions to raucous and unforgettable evenings'),
-				L.marker([13.75, -9.05], setMarker(signpostIcon)).bindLabel('Hanged Man\'s Tree').bindPopup('<h1>Hanged Man\'s Tree</h1>During the war, both sides committed acts of exorbitant cruelty meant to keep the conquered populaces in check'),
-				L.marker([5.22, 5.41], setMarker(signpostIcon)).bindLabel('Devil\'s Pit').bindPopup('<h1>Devil\'s Pit</h1>The inhabitants of Velen believe the expanse of caverns underneath the Devil\'s Pit are home to demons'),
-				L.marker([1.43, -15.16], setMarker(signpostIcon)).bindLabel('Mulbrydale').bindPopup('<h1>Mulbrydale</h1>One of the oldest villages in the region. Owes its name to a certain undereducated botanist who could not discern one kind of tree from another and so called them all mulberries'),
-				L.marker([0.82, -47.20], setMarker(signpostIcon)).bindLabel('Inn at the Crossroads').bindPopup('<h1>Inn at the Crossroads</h1>A sizeable establishment able to accommodate a crowd of travelers and revelers'),
-			// NW Velen
-				L.marker([21.78, -106.54], setMarker(signpostIcon)).bindLabel('Harpy Feeding Ground').bindPopup('<h1>Harpy Feeding Ground</h1>One of those places entered by only the very brave, or very foolish'),
-				L.marker([30.56, -114.31], setMarker(signpostIcon)).bindLabel('Lornruk').bindPopup('<h1>Lornruk</h1>Years ago smugglers would come here to load and unload illicit cargo'),
-				L.marker([-1.85, -98.61], setMarker(signpostIcon)).bindLabel('Heatherton').bindPopup('<h1>Heatherton</h1>The inhabitants of this village were relieved when they learned the path of the marching armies had shifted slightly and passed their village bye. Then, one night... they changed their mind'),
-				L.marker([0.97, -110.39], setMarker(signpostIcon)).bindLabel('Abandoned Tower').bindPopup('<h1>Abandoned Tower</h1>Legend has it a beleaguered traveler once stood at this tower\'s gates. He begged for shelter for the night, claiming he\'d been injured, but the baron living inside was afraid the traveler was a spy and sent him away. Little did he know the traveler was a powerful mage, who cast a curse on the tower, its inhospitable owner and all who dwelled with him. Soon thereafter the baron and all his retinue died in mysterious circumstances, and the tower fell into ruin'),
-				L.marker([2.37, -122.34], setMarker(signpostIcon)).bindLabel('Isolated Shack').bindPopup('<h1>Isolated Shack</h1>Small hut constructed by a famous sculptor who, having garnered every laurel possible for his trade, abandoned his Koviri residence and moved here in order to find inspiration in solitude and reflect on what to make of the rest of his life'),
-				L.marker([-28.27, -103.97], setMarker(signpostIcon)).bindLabel('Blackbough').bindPopup('<h1>Blackbough</h1>This village takes its name from the unwanted limbs loggers used to bring here to burn, leaving stacks of charred logs behind. The locals, however, prefer the old legend which holds that their village was founded by a prominent member of an ancient race of tree people'),
-				L.marker([-32.44, -123.05], setMarker(signpostIcon)).bindLabel('Hangman\'s Alley').bindPopup('<h1>Hangman\'s Alley</h1>The road is lined with the hanged bodies of peasants who opposed their new rulers or had the bad luck of happening across bandits who had nothing against adding another dangling installation to the boulevard\'s scenery'),
-				L.marker([-39.71, -74.62], setMarker(signpostIcon)).bindLabel('Crow\'s Perch').bindPopup('<h1>Crow\'s Perch</h1>After Vserad, its previous owner, panicked at the news that armies were approaching and fled to Fyke Isle, this castle became home to Phillip Strenger, alias the Bloody Baron, along with his family and entourage'),
-				L.marker([-52.81, -55.63], setMarker(signpostIcon)).bindLabel('Boatmakers\' Hut').bindPopup('<h1>Boatmakers\' Hut</h1>Though nothing about this small domicile is particularly eye-catching, a family of the best shipwrights in Velen has lived here for generations, crafting the finest skiffs and dinghies north of the Yaruga'),
-				L.marker([-50.35, -140.98], setMarker(signpostIcon)).bindLabel('Regugees\' Camp').bindPopup('<h1>Regugees\' Camp</h1>The members of this small community have erected a large, winged statue - evidence of people turning to old gods and ancient cults in this time of war and famine'),
-				L.marker([-45.01, -140.36], setMarker(signpostIcon)).bindLabel('Coast of Wrecks').bindPopup('<h1>Coast of Wrecks</h1>Once the local youth would come here to revel amidst the wrecks. Now inhabitants of nearby villages have started combing the place day and night in search of anything that can be exchanged for food'),
-				L.marker([-53.67, -119.50], setMarker(signpostIcon)).bindLabel('Midcopse').bindPopup('<h1>Midcopse</h1>Typical farming settlement which the worst of the fighting has left untouched - but which famine now grips all the same. One of the larger villages in this region'),
-				L.marker([-57.30, -98.57], setMarker(signpostIcon)).bindLabel('Wastrel Manor').bindPopup('<h1>Wastrel Manor</h1>The once-beautiful manor house located near here was known for its extravagant balls, which were attended by the cream of the local youth. Its owners abandoned it over a century ago, but soon afterwards it became a place of worship for the local community, which believes a deity dwells in the ruins'),
-				L.marker([-62.01, -34.94], setMarker(signpostIcon)).bindLabel('Bandit\'s Camp').bindPopup('<h1>Bandits\' Camp</h1>A place some particularly nasty characters have decided to call home'),
-				L.marker([-63.55, -74.44], setMarker(signpostIcon)).bindLabel('Oreton').bindPopup('<h1>Oreton</h1>Village founded by Count Primislavus don Stessa, distant cousin to King Foltest of Temeria. The count was known for his passion for racing chariots down winding forest paths and narrow country roads. This spectacle delighted onlookers, won the hearts of the highborn ladies and aroused hatred in his rivals'),
-				L.marker([-45.68, -127.05], setMarker(signpostIcon)).bindLabel('Forest Hut').bindPopup('<h1>Forest Hut</h1>Though his friends advised against building a house in the middle of the woods, Hans refused to listen and did things his way. When the war broke out and laid waste to this region, Hans and his family lived in peace, untouched by the troubles of the wider world - until one fateful night...'),
-				L.marker([-13.67, -84.20], setMarker(signpostIcon)).bindLabel('Wolven Glade').bindPopup('<h1>Wolven Glade</h1>A long, long time ago, when this land was ruled by forest spirits and ancient gods, the living would come here to pay their respects to the dead in the way their holy tome comanded: "Walk thee in darkness, on a path of blood, standing under bare sky, naked before the gods and their messengers."'),
-				L.marker([-28.84, -60.56], setMarker(signpostIcon)).bindLabel('Burned Ruins').bindPopup('<h1>Burned Ruins</h1>One of many structures in the area which did not survive the onslaught of war'),
-				L.marker([-47.10, -92.64], setMarker(signpostIcon)).bindLabel('Troll Bridge').bindPopup('<h1>Troll Bridge</h1>Local legend has it this bridge was erected by trolls who were later killed by an anonymous witcher'),
-				L.marker([-53.96, -80.86], setMarker(signpostIcon)).bindLabel('Claywich').bindPopup('<h1>Claywich</h1>Every year at Belleteyn, a great feast is held in Claywich accompanied by games, song and dance. On that night villagers from far and wide come to celebrate, with passing travelers welcome as well. Shortly before midnight the youth in attendance race deep into the forest in search of a fern flower, and though no one has as yet found one, many have found their other halves, or at least a night of moonlight passion'),
-				L.marker([-69.33, -39.59], setMarker(signpostIcon)).bindLabel('Drudge').bindPopup('<h1>Drudge</h1>This once-peaceful fishermen\'s settlement now stands almost completely empty. Road-weary travelers sometimes find shelter in its abandoned huts - besides that, not a soul is to be seen'),
-			// SW Velen
-				L.marker([-64.09, -147.83], setMarker(signpostIcon)).bindLabel('Condyle').bindPopup('<h1>Condyle</h1>This village has been completely and utterly destroyed. Rumors claim its inhabitants perished in a gruesome massacre'),
-				L.marker([-65.73, -128.41], setMarker(signpostIcon)).bindLabel('Duen Hen').bindPopup('<h1>Duen Hen</h1>Religious site where the old gods are worshipped'),
-				L.marker([-73.30, -69.92], setMarker(signpostIcon)).bindLabel('Fyke Isle').bindPopup('<h1>Fyke Isle</h1>Ruined tower which is said to be afflicted by a terrible curse'),
-				L.marker([-77.12, -112.72], setMarker(signpostIcon)).bindLabel('Byways').bindPopup('<h1>Byways</h1>Most of this area\'s residents have fled north or died of plague. In better times they busied themselves making prize-winning bricks'),
-				L.marker([-80.79, -69.83], setMarker(signpostIcon)).bindLabel('Frischlow').bindPopup('<h1>Frischlow</h1>Like many other settlements in the area, this one has suffered greatly on account of the war. Its inhabitants have abandoned their property and evacuated lands in which they once dwelled in relative peace'),
-				L.marker([-78.73, -41.44], setMarker(signpostIcon)).bindLabel('Olena\'s Grove').bindPopup('<h1>Olena\'s Grove</h1>Legends claim that a beautiful nymph named Olena once lived in this grove. She fell in love with a young hunter and the man swore to be true to the nymph, but later betrayed her. She decided to punish him by casting a spell on his spirit, which wanders the grove to this day'),
-			// SE Velen
-				L.marker([-79.15, -10.28], setMarker(signpostIcon)).bindLabel('Road to Bald Mountain').bindPopup('<h1>Road to Bald Mountain</h1>The peasants of Velen believe the summit of Bald Mountain is home to witches, werebbubbs and wights'),
-				L.marker([-80.90, 30.32], setMarker(signpostIcon)).bindLabel('Destroyed Bastion').bindPopup('<h1>Destroyed Bastion</h1>Bastion built during the reign of King Gardic and destroyed during the First Nilfgaardian War'),
-				L.marker([-76.49, 41.62], setMarker(signpostIcon)).bindLabel('Crossroads').bindPopup('<h1>Crossroads</h1>A small crossroads, well trodden by the inhabitants of the surrounding villages'),
-				L.marker([-77.56, 110.92], setMarker(signpostIcon)).bindLabel('Nilfgaardian Army Group \'Center\' Camp').bindPopup('<h1>Nilfgaardian Army Group \'Center\' Camp</h1>Pitched in a mere two weeks, the Army Group \'Center\' camp constitutes the quintessence of Nilfgaardian martial architecture'),
-				L.marker([-74.73, 98.61], setMarker(signpostIcon)).bindLabel('House of Respite').bindPopup('<h1>House of Respite</h1>The House of Respite\'s motto: "A soldier does not live on war alone." This is slightly misleading, however, for the club is not open to all soldiers, only Nilfgaardian officers (or those capable of passing themselves off as such)'),
-				L.marker([-69.16, 82.13], setMarker(signpostIcon)).bindLabel('Kimbolt Way').bindPopup('<h1>Kimbolt Way</h1>Road built on orders of Baron Kimbolt, meant to act as a safe escape route in case his plans to take power after King Foltest\'s death went awry'),
-				L.marker([-67.09, 22.19], setMarker(signpostIcon)).bindLabel('The Orphans of Crookback Bog').bindPopup('<h1>The Orphans of Crookback Bog</h1>Orphaned and unwanted children from nearby villages find a roof over their head and a bowl of warm food here'),
-				L.marker([-65.05, 37.53], setMarker(signpostIcon)).bindLabel('Ruined Tower').bindPopup('<h1>Ruined Tower</h1>Five centuries ago King Geddes sent his most loyal knight, Martin of Oakdale, to watch over the inhabitants of this troubled land. He also sent his least-loyal knight, to scrub Martin\'s latrines'),
-				L.marker([-70.73, 43.68], setMarker(signpostIcon)).bindLabel('Ancient Oak').bindPopup('<h1>Ancient Oak</h1>Centuries ago bloody rituals in honor of the old gods were conducted here. Locals believe dark forces still haunt this place'),
-				L.marker([-58.79, 30.63], setMarker(signpostIcon)).bindLabel('Downwarren').bindPopup('<h1>Downwarren</h1>Before the war, the inhabitants of this village were known for their intricate lacemaking and artisanal smithery'),
-				L.marker([-54.39, 10.99], setMarker(signpostIcon)).bindLabel('Dragonslayer\'s Grotto').bindPopup('<h1>Dragonslayer\'s Grotto</h1>Underneath this fortress lies a musty, rank cave in which a lost traveler will find nothing but a few fattened leeches - if he\'s lucky. Nevertheless, village elders insist on repeating the legend that gave the grotto its name: that of a legendary dragonslayer said to be buried somewhere deep inside'),
-				L.marker([-48.75, 30.72], setMarker(signpostIcon)).bindLabel('Reardon Manor').bindPopup('<h1>Reardon Manor</h1>Abandoned estate of the once prominent Reardon family, relatives to the royal La Louve dynasty'),
-				L.marker([-50.63, 67.32], setMarker(signpostIcon)).bindLabel('Benek').bindPopup('<h1>Benek</h1>This small village owes its name to its founding elder, who erected the largest windmill the land had ever seen on this spot - thereby providing work for all the village\'s inhabitants'),
-				L.marker([-36.10, 51.68], setMarker(signpostIcon)).bindLabel('Toderas').bindPopup('<h1>Toderas</h1>Village founded by King Griffin of Temeria, the husband of Clarissa of Toussaint. The king had planned to turn Toderas into a large, bustling university city, a sort of Temerian alternative to Oxenfurt, but, as any visitor can quickly attest, his efforts failed utterly'),
-				L.marker([-34.42, 11.69], setMarker(signpostIcon)).bindLabel('Lurtch').bindPopup('<h1>Lurtch</h1>Once the Evves family estate was located here and the area bore the name of Lord Evves\' wife, Mortilanca. When the couple died, their will stipulated their land be turned over to their serfs. The grateful peasants then founded a village of freeholders and named it after their first ealdorman, Lurtch, who had previously served as the Evves family\'s butler'),
-				L.marker([-36.81, -25.97], setMarker(signpostIcon)).bindLabel('Lindenvale').bindPopup('<h1>Lindenvale</h1>One of Velen\'s many impoverished villages, its poverty deepened by war levies and the epidemic that spread after the Nilfgaardians\' arrival'),
-				L.marker([-17.22, 40.17], setMarker(signpostIcon)).bindLabel('Marauders\' Bridge').bindPopup('<h1>Marauders\' Bridge</h1>After the Battle of Velen, marauders swarmed over this bridge in their rush to scavenge the battlefield'),
-				L.marker([-22.92, 71.59], setMarker(signpostIcon)).bindLabel('Grotto').bindPopup('<h1>Grotto</h1>A dark and hostile place which creaks from time to time with unsettling, throaty noises...'),
-		]);
+	markers.signpost = L.layerGroup([
+		// Novigrad
+			createMarker([73.76, -33.97], icons.signpost, 'Hierarch Square', '<h1>Hierarch Square</h1>Until quite recently a great many mages lived near Novigrad\'s main square. They fled when the witch hunters began their reign of terror, leaving many of the city\'s most beautiful townhouses abandoned and uncared for'),
+			createMarker([74.23, -15.86], icons.signpost, 'Southern Gate', '<h1>Southern Gate</h1>In truth demarcating the eastern and not southern edge of the city, the Southern Gate was given its inappropriate name by a one-time city planner who knew nothing about architecture and could not read a map, but had in his favor the fact that he was the mayor\'s cousin and thew lavish parties. Though confusingly incorrect, the name stuck and now the city\'s residents never think twice about its illogical appellation'),
+			createMarker([76.44, -16.20], icons.signpost, 'Oxenfurt Gate', '<h1>Oxenfurt Gate</h1>In the times when Novigrad and Oxenfurt were embroiled in fierce neighborly disputes, this gate went through several completely different names, the Gate of Harlots and the Gate of Bloodsuckers being two of the longer lived examples. Its current name was chosen when this conflict was finally put to rest'),
+			createMarker([77.64, -36.47], icons.signpost, 'St. Gregory\'s Bridge', '<h1>St. Gregory\'s Bridge</h1>Bridge named after the hero of Novigrad who saved the city from a horrible famine three hundred years ago by sacrificing half his fortune to import food from Nazair. After this, he was declared a saint, something even the jurors of the Church of the Eternal Fire were unable to change'),
+			createMarker([79.73, -51.24], icons.signpost, 'Electors\' Square', '<h1>Electors\' Square</h1>Square named after a group of Novigrad reformers who enacted bold transformations that led to the city\'s rapid growth, enriching its residents considerably and ushering in the city\'s golden age'),
+			createMarker([71.16, -22.94], icons.signpost, 'Tretogor Gate', '<h1>Tretogor Gate</h1>Gate erected with funds from the Redanian royal family, who, wanting to earn favor with Novigrad merchants and the hierach, dedicated a significant amount of coin to its construction, as well as some no-less-valuable (wo)manpower in the form of the master architect Countess Anna Yaye-Pinkovitz and her skilled crew'),
+			createMarker([68.94, -27.77], icons.signpost, 'Gate of the Hierarch', '<h1>Gate of the Hierarch</h1>This gate is named in honor of Novigrad\'s own son, the Hierach of the eternal Fire. Supposedly this name was given to it upon popular request, though no one can be found who remembers requesting any such thing'),
+			createMarker([66.32, -35.31], icons.signpost, 'Glory Gate', '<h1>Glory Gate</h1>Toughs and hooligans often end a night of drunken escapades under this gate after being thrown out of the nearby taverns'),
+			createMarker([65.99, -43.90], icons.signpost, 'Portside Gate', '<h1>Portside Gate</h1>Though not the most stately of gates, this one\'s location near the bustling port has made it the calling card of the city'),
+			createMarker([69.57, -55.28], icons.signpost, 'Novigrad Docks', '<h1>Novigrad Docks</h1>A den of dirt and depravity and the shadiest part of Novigrad. After dark all one finds here are women of loose morals, hoodlums and drunk sailors'),
+			createMarker([75.39, -8.88], icons.signpost, 'Arette', '<h1>Arette</h1>Novigrad has always attracted those in search of a better life. Some of them found no welcome within the city walls, and so built huts outside the city'),
+			createMarker([69.57, -2.81], icons.signpost, 'Seven Cats Inn', '<h1>Seven Cats Inn</h1>This dank establishment is host to a shady clientele'),
+		// NE Novigrad
+			createMarker([83.53, -9.40], icons.signpost, 'Sarrasin Grange', '<h1>Sarrasin Grange</h1>Lord Antares Sarrasin moved his wife and smattering of comely daughters here from far-off Nazair on his medic\'s recommendations. The leech proclaimed with absolute certainy that "if you wish to sire a son, it must be in the Gustfields." While waiting to produce a male heir, the Sarrasins took to wine cultivation and soon their grange became renowned from Nazair to Skellige'),
+			createMarker([81.92, 3.60], icons.signpost, 'Yantra', '<h1>Yantra</h1>The inhabitants of this village are known for their talkativeness and tendency to exagerrate, which makes them good companions for a round of drink, but impossible to tolerate for long stretches of time'),
+			createMarker([82.09, 30.15], icons.signpost, 'Isolated Hut', '<h1>Isolated Hut</h1>Rumors claim a famous painter lives in this house, though no one has ever seen him or knows his name'),
+			createMarker([76.24, 18.26], icons.signpost, 'Honeyfill Meadworks', '<h1>Honeyfill Meadworks</h1>The renowned Honeyfill Meadworks has for generations belonged to a respected family of halflings'),
+			createMarker([79.04, 65.21], icons.signpost, 'Martin Feuille\'s Farmstead', '<h1>Martin Feuille\'s Farmstead</h1>Founded by Lord Martin Feuille, this vast plantation was until not so long ago the largest producer of alfalfa in the region. Sadly, when war broke out the lord fled to his winter residence in Kovir, leaving his land to be administered by an ill-suited stward who squandered his liege\'s fertile fields'),
+			createMarker([81.02, 49.09], icons.signpost, 'Winespring Grange', '<h1>Winespring Grange</h1>Years ago, an eccentric count named Jacobus Ruth of the Rieslings settled here. The count could not stand the pomposity of court life but loved good wine. He thus planted a vineyard here which produces a fabulous beaujolais prized on both sides of the Pontar'),
+			createMarker([79.59, 31.03], icons.signpost, 'Moldavie Residence', '<h1>Moldavie Residence</h1>Despite its ideal location and beautiful surroundings, this residence has been tossed from owner to owner like a hot potato, and for some unknown reason suffers from a bad reputation'),
+			createMarker([81.66, -31.55], icons.signpost, 'Cavern', '<h1>Cavern</h1>One of those places wise men avoid at all costs, so as not to tempt fate'),
+		// E Novigrad
+			createMarker([72.92, 41.31], icons.signpost, 'Alness', '<h1>Alness</h1>Until recently, this was a thoroughly unremarkable village. then the Vegelbuds began organizing their famous horse races here, granting Alness the enviable honor of hosting the region\'s most pretigious equestrian contests'),
+			createMarker([67.58, 31.03], icons.signpost, 'Wheat Fields', '<h1>Wheat Fields</h1>The fertile soils of the Pontar delta guarantee the inhabitants of Novigrad full granaries and full stomaches all year long'),
+			createMarker([65.31, 46.67], icons.signpost, 'Vegelbud Residence', '<h1>Vegelbud Residence</h1>Domicile of a prominent Novigrad family whose line can be traced back to the times when the first human settlers came to these lands'),
+		// SE Novigrad
+			createMarker([62.02, 39.11], icons.signpost, 'Carsten', '<h1>Carsten</h1>A village named after a baker whose exquisite goods gained him fame, as well as the privilege of supplying bread to the table of the hierarch of the Church of the Eternal Fire in Novigrad. Following his death, none proved capable of recreating his recipes for his delicious and depply aromatic breads, so these days Carsten is known chiefly for its trade in grain and flour'),
+			createMarker([58.56, 66.27], icons.signpost, 'Temerian Partisan Hideout', '<h1>Temerian Partisan Hideout</h1>Though the Nilfgaardians thought Temeria died along with King Foltest, Temerian guerillas still hide in the woods, prepared to give their lives at a moment\'s notice in their fight for independence'),
+			createMarker([59.82, 85.87], icons.signpost, 'Est Tayiar', '<h1>Est Tayiar</h1>Long before men first peopled these lands, a beautiful, prospering elven city stood here, centered around the palace of King Maeglor. One day, however, the city\'s inhabitants began mysteriously dying off in large numbers. According to legend, King Maeglor sensed he, too, would soon perish and cast a powerful spell that caused the earth to swallow the city whole so that no outsider could ever desecrate it. Centuries later, scholars from the Oxenfurt Academy began painstaking excavations of King Maeglor\'s palace in a search for the causes of the catastrophe. Yet work came to a sudden halt when three subsequent expeditions ventured into the ruins\' depths - and were never heard from again...'),
+			createMarker([49.45, 70.67], icons.signpost, 'Herbalist\'s Hut', '<h1>Herbalist\'s Hut</h1>Home to a halfling herbalist who is a passionate devotee of innovative gardening methods and experimental herbal medicine'),
+			createMarker([35.51, 110.67], icons.signpost, 'Aeramas\' Abandoned Manor', '<h1>Aeramas\' Abandoned Manor</h1>Peasants living nearby often complain about the overwhelming cheese stench wafting out of this residence...'),
+			createMarker([19.89, 83.06], icons.signpost, 'Crossroads', '<h1>Crossroads</h1>A small crossroads in the woods'),
+			createMarker([49.85, 52.73], icons.signpost, 'Gustfields Farm', '<h1>Gustfields Farm</h1>Farmstead founded years ago by an eccentric flaxen-haired painter named Cunigund de Cabbrae, who came here seeking peace, quiet and fresh country air'),
+			createMarker([76.64, 37.00], icons.signpost, 'Dancing Windmill', '<h1>Dancing Windmill</h1>When the current owner\'s grandfather, the famous dancer Pablo "Sugar" Sasko, ended his career, he settled here and organised nights of dancing for the nearby peasantry. Supposedly these revelries became so fashionable that dung-booted peasants were dancing rounds with members of Novigrad\'s most elite familes and adventure-seeking urban dandies'),
+		// S Novigrad
+			createMarker([67.20, -65.48], icons.signpost, 'Loggers Hut', '<h1>Loggers Hut</h1>A lone cabin deep in the Novigrad Forest - an ideal base for woodcutters'),
+			createMarker([66.92, -85.25], icons.signpost, 'Lighthouse', '<h1>Lighthouse</h1>Many years ago a horrible accident took place here: a ship carrying the cousin of King Radovid IV the Bald wrecked against the rocks during a storm. The king ordered a lighthouse erected on that spot in order to warn other seafarers of its deadly danger'),
+			createMarker([61.90, -14.08], icons.signpost, 'Cunny of the Goose', '<h1>Cunny of the Goose</h1>This inn owes its name to its former owner, a swaggering, blustering fellow who wanted to attract those of a similar temperatment. Luckily he died of liver poisoning after a few years and ownership passed to a distant relative, who turned the Cunny of the Goose into the best spot for stuffed goose liver in all the region'),
+			createMarker([58.03, -29.44], icons.signpost, 'Drahim Castle', '<h1>Drahim Castle</h1>In its glory years, this castle was home to the Redanian Moskovitz of the Sea Cats dynasty, patrons of the arts and admirers of elven culture. After the death by suicide of the dynasty\'s last member, Prince Adrien, the castle fell into the hands of the Redanian crown - and then into ruin'),
+			createMarker([54.10, -71.98], icons.signpost, 'Widows\' Grotto', '<h1>Widows\' Grotto</h1>According to legend, many years ago a young woman would wait here and watch for her husband\'s return from an overseas raid. Years passed and the woman grew old, still waiting for her husband. Yet he never came, and finally, she died. Three days after her funeral, her husband returned, having at last escaped from the pirates who had held him captive all that time. When he learned about his beloved\'s loyal vigil, he wept bitter tears, then lept to his death'),
+			createMarker([45.98, -51.33], icons.signpost, 'Ursten', '<h1>Ursten</h1>War has caused countless refugees to flee Temeria. With the Pontar blockaded, they have tended to flood villages which, like Ursten, are located close to river crossings'),
+			createMarker([60.50, -55.55], icons.signpost, 'Lucian\'s Windmill', '<h1>Lucian\'s Windmill</h1>Lucian le Foix, the famous Oxenfurt sculptor and architect, bought this windmill several years ago and made it into his country retreat. Sadly the enormous popularity of the great Lucian\'s designs means he spends little time in his fortress of solitude and has entrusted its care to a steward'),
+			createMarker([62.35, 11.69], icons.signpost, 'Eternal Fire Chapel', '<h1>Eternal Fire Chapel</h1>This shrine greets travelers on their way to Oxenfurt. Merchants sometimes stop here to sell goods to pilgrims and visiting scholars'),
+			createMarker([37.11, -27.23], icons.signpost, 'Border Post', '<h1>Border Post</h1>A small isle stuck in the river\'s central current - an ideal place for bleaching cloth'),
+		// Oxenfurt
+			createMarker([38.17, 62.31], icons.signpost, 'Novigrad Gate', '<h1>Novigrad Gate</h1>During Oxenfurt Academy\'s exam sessions, this gate would be closed, to spare the students from Novigrad\'s temptations'),
+			createMarker([29.10, 52.58], icons.signpost, 'Western Gate', '<h1>Western Gate</h1>Before war broke out, several hundred people a day would pass through here. Now the Redanian blockade has slowed traffic to a mere trickle'),
+			createMarker([37.40, 48.34], icons.signpost, 'Oxenfurt Harbor', '<h1>Oxenfurt Harbor</h1>Oxenfurt\'s picturesque port has featured as the subject of numerous odes and ballads, the setting for at least three lurid crime novels, and a favorite spot for romantic outings for generations of students'),
+		// NE Velen
+			createMarker([15.62, 25.66], icons.signpost, 'Stonecutters\' Settlement', '<h1>Stonecutters\' Settlement</h1>Over Twenty years ago a certain Bartolomeo, known as "Badger" on account of certain characteristic aspects of his coiffure, discovered a rich deposit of high-quality stone on this spot. He bought the land for a song, then leased it back to local peasants before heading off to Kovir, where he lives the life of a rich and powerful townsman to this day'),
+			createMarker([35.96, 34.41], icons.signpost, 'White Eagle Fort', '<h1>White Eagle Fort</h1>The grand name might seem in ill-fitting with this place, but the troll that lives here - a Redanian patriot and military aficionado - goes to great lengths to make his beloved King Radovid proud'),
+			createMarker([27.45, 12.00], icons.signpost, 'Codgers\' Quarry', '<h1>Codgers\' Quarry</h1>The now-inactive quarry once only employed stonebreakers over thirty years of age who would work hard all day, then spend the evenings racing down the sides of the quarry pit on hand-crafted wagons'),
+			createMarker([39.61, -2.42], icons.signpost, 'Hindhold', '<h1>Hindhold</h1>This watchtower used to protect barges traveling between Oxenfurt and Novigrad. It once even boasted a bridge connecting the two sides of the river, but now it stands abandoned and neglected, its bridge a collapsed ruin'),
+			createMarker([-4.01, 63.37], icons.signpost, 'Ferry Station', '<h1>Ferry Station</h1>The ferry\'s former owners were famed for treating travelers who were forced to wait for better conditions to raucous and unforgettable evenings'),
+			createMarker([13.75, -9.05], icons.signpost, 'Hanged Man\'s Tree', '<h1>Hanged Man\'s Tree</h1>During the war, both sides committed acts of exorbitant cruelty meant to keep the conquered populaces in check'),
+			createMarker([5.22, 5.41], icons.signpost, 'Devil\'s Pit', '<h1>Devil\'s Pit</h1>The inhabitants of Velen believe the expanse of caverns underneath the Devil\'s Pit are home to demons'),
+			createMarker([1.43, -15.16], icons.signpost, 'Mulbrydale', '<h1>Mulbrydale</h1>One of the oldest villages in the region. Owes its name to a certain undereducated botanist who could not discern one kind of tree from another and so called them all mulberries'),
+			createMarker([0.82, -47.20], icons.signpost, 'Inn at the Crossroads', '<h1>Inn at the Crossroads</h1>A sizeable establishment able to accommodate a crowd of travelers and revelers'),
+		// NW Velen
+			createMarker([21.78, -106.54], icons.signpost, 'Harpy Feeding Ground', '<h1>Harpy Feeding Ground</h1>One of those places entered by only the very brave, or very foolish'),
+			createMarker([30.56, -114.31], icons.signpost, 'Lornruk', '<h1>Lornruk</h1>Years ago smugglers would come here to load and unload illicit cargo'),
+			createMarker([-1.85, -98.61], icons.signpost, 'Heatherton', '<h1>Heatherton</h1>The inhabitants of this village were relieved when they learned the path of the marching armies had shifted slightly and passed their village bye. Then, one night... they changed their mind'),
+			createMarker([0.97, -110.39], icons.signpost, 'Abandoned Tower', '<h1>Abandoned Tower</h1>Legend has it a beleaguered traveler once stood at this tower\'s gates. He begged for shelter for the night, claiming he\'d been injured, but the baron living inside was afraid the traveler was a spy and sent him away. Little did he know the traveler was a powerful mage, who cast a curse on the tower, its inhospitable owner and all who dwelled with him. Soon thereafter the baron and all his retinue died in mysterious circumstances, and the tower fell into ruin'),
+			createMarker([2.37, -122.34], icons.signpost, 'Isolated Shack', '<h1>Isolated Shack</h1>Small hut constructed by a famous sculptor who, having garnered every laurel possible for his trade, abandoned his Koviri residence and moved here in order to find inspiration in solitude and reflect on what to make of the rest of his life'),
+			createMarker([-28.27, -103.97], icons.signpost, 'Blackbough', '<h1>Blackbough</h1>This village takes its name from the unwanted limbs loggers used to bring here to burn, leaving stacks of charred logs behind. The locals, however, prefer the old legend which holds that their village was founded by a prominent member of an ancient race of tree people'),
+			createMarker([-32.44, -123.05], icons.signpost, 'Hangman\'s Alley', '<h1>Hangman\'s Alley</h1>The road is lined with the hanged bodies of peasants who opposed their new rulers or had the bad luck of happening across bandits who had nothing against adding another dangling installation to the boulevard\'s scenery'),
+			createMarker([-39.71, -74.62], icons.signpost, 'Crow\'s Perch', '<h1>Crow\'s Perch</h1>After Vserad, its previous owner, panicked at the news that armies were approaching and fled to Fyke Isle, this castle became home to Phillip Strenger, alias the Bloody Baron, along with his family and entourage'),
+			createMarker([-52.81, -55.63], icons.signpost, 'Boatmakers\' Hut', '<h1>Boatmakers\' Hut</h1>Though nothing about this small domicile is particularly eye-catching, a family of the best shipwrights in Velen has lived here for generations, crafting the finest skiffs and dinghies north of the Yaruga'),
+			createMarker([-50.35, -140.98], icons.signpost, 'Regugees\' Camp', '<h1>Regugees\' Camp</h1>The members of this small community have erected a large, winged statue - evidence of people turning to old gods and ancient cults in this time of war and famine'),
+			createMarker([-45.01, -140.36], icons.signpost, 'Coast of Wrecks', '<h1>Coast of Wrecks</h1>Once the local youth would come here to revel amidst the wrecks. Now inhabitants of nearby villages have started combing the place day and night in search of anything that can be exchanged for food'),
+			createMarker([-53.67, -119.50], icons.signpost, 'Midcopse', '<h1>Midcopse</h1>Typical farming settlement which the worst of the fighting has left untouched - but which famine now grips all the same. One of the larger villages in this region'),
+			createMarker([-57.30, -98.57], icons.signpost, 'Wastrel Manor', '<h1>Wastrel Manor</h1>The once-beautiful manor house located near here was known for its extravagant balls, which were attended by the cream of the local youth. Its owners abandoned it over a century ago, but soon afterwards it became a place of worship for the local community, which believes a deity dwells in the ruins'),
+			createMarker([-62.01, -34.94], icons.signpost, 'Bandit\'s Camp', '<h1>Bandits\' Camp</h1>A place some particularly nasty characters have decided to call home'),
+			createMarker([-63.55, -74.44], icons.signpost, 'Oreton', '<h1>Oreton</h1>Village founded by Count Primislavus don Stessa, distant cousin to King Foltest of Temeria. The count was known for his passion for racing chariots down winding forest paths and narrow country roads. This spectacle delighted onlookers, won the hearts of the highborn ladies and aroused hatred in his rivals'),
+			createMarker([-45.68, -127.05], icons.signpost, 'Forest Hut', '<h1>Forest Hut</h1>Though his friends advised against building a house in the middle of the woods, Hans refused to listen and did things his way. When the war broke out and laid waste to this region, Hans and his family lived in peace, untouched by the troubles of the wider world - until one fateful night...'),
+			createMarker([-13.67, -84.20], icons.signpost, 'Wolven Glade', '<h1>Wolven Glade</h1>A long, long time ago, when this land was ruled by forest spirits and ancient gods, the living would come here to pay their respects to the dead in the way their holy tome comanded: "Walk thee in darkness, on a path of blood, standing under bare sky, naked before the gods and their messengers."'),
+			createMarker([-28.84, -60.56], icons.signpost, 'Burned Ruins', '<h1>Burned Ruins</h1>One of many structures in the area which did not survive the onslaught of war'),
+			createMarker([-47.10, -92.64], icons.signpost, 'Troll Bridge', '<h1>Troll Bridge</h1>Local legend has it this bridge was erected by trolls who were later killed by an anonymous witcher'),
+			createMarker([-53.96, -80.86], icons.signpost, 'Claywich', '<h1>Claywich</h1>Every year at Belleteyn, a great feast is held in Claywich accompanied by games, song and dance. On that night villagers from far and wide come to celebrate, with passing travelers welcome as well. Shortly before midnight the youth in attendance race deep into the forest in search of a fern flower, and though no one has as yet found one, many have found their other halves, or at least a night of moonlight passion'),
+			createMarker([-69.33, -39.59], icons.signpost, 'Drudge', '<h1>Drudge</h1>This once-peaceful fishermen\'s settlement now stands almost completely empty. Road-weary travelers sometimes find shelter in its abandoned huts - besides that, not a soul is to be seen'),
+		// SW Velen
+			createMarker([-64.09, -147.83], icons.signpost, 'Condyle', '<h1>Condyle</h1>This village has been completely and utterly destroyed. Rumors claim its inhabitants perished in a gruesome massacre'),
+			createMarker([-65.73, -128.41], icons.signpost, 'Duen Hen', '<h1>Duen Hen</h1>Religious site where the old gods are worshipped'),
+			createMarker([-73.30, -69.92], icons.signpost, 'Fyke Isle', '<h1>Fyke Isle</h1>Ruined tower which is said to be afflicted by a terrible curse'),
+			createMarker([-77.12, -112.72], icons.signpost, 'Byways', '<h1>Byways</h1>Most of this area\'s residents have fled north or died of plague. In better times they busied themselves making prize-winning bricks'),
+			createMarker([-80.79, -69.83], icons.signpost, 'Frischlow', '<h1>Frischlow</h1>Like many other settlements in the area, this one has suffered greatly on account of the war. Its inhabitants have abandoned their property and evacuated lands in which they once dwelled in relative peace'),
+			createMarker([-78.73, -41.44], icons.signpost, 'Olena\'s Grove', '<h1>Olena\'s Grove</h1>Legends claim that a beautiful nymph named Olena once lived in this grove. She fell in love with a young hunter and the man swore to be true to the nymph, but later betrayed her. She decided to punish him by casting a spell on his spirit, which wanders the grove to this day'),
+		// SE Velen
+			createMarker([-79.15, -10.28], icons.signpost, 'Road to Bald Mountain', '<h1>Road to Bald Mountain</h1>The peasants of Velen believe the summit of Bald Mountain is home to witches, werebbubbs and wights'),
+			createMarker([-80.90, 30.32], icons.signpost, 'Destroyed Bastion', '<h1>Destroyed Bastion</h1>Bastion built during the reign of King Gardic and destroyed during the First Nilfgaardian War'),
+			createMarker([-76.49, 41.62], icons.signpost, 'Crossroads', '<h1>Crossroads</h1>A small crossroads, well trodden by the inhabitants of the surrounding villages'),
+			createMarker([-77.56, 110.92], icons.signpost, 'Nilfgaardian Army Group \'Center\' Camp', '<h1>Nilfgaardian Army Group \'Center\' Camp</h1>Pitched in a mere two weeks, the Army Group \'Center\' camp constitutes the quintessence of Nilfgaardian martial architecture'),
+			createMarker([-74.73, 98.61], icons.signpost, 'House of Respite', '<h1>House of Respite</h1>The House of Respite\'s motto: "A soldier does not live on war alone." This is slightly misleading, however, for the club is not open to all soldiers, only Nilfgaardian officers (or those capable of passing themselves off as such)'),
+			createMarker([-69.16, 82.13], icons.signpost, 'Kimbolt Way', '<h1>Kimbolt Way</h1>Road built on orders of Baron Kimbolt, meant to act as a safe escape route in case his plans to take power after King Foltest\'s death went awry'),
+			createMarker([-67.09, 22.19], icons.signpost, 'The Orphans of Crookback Bog', '<h1>The Orphans of Crookback Bog</h1>Orphaned and unwanted children from nearby villages find a roof over their head and a bowl of warm food here'),
+			createMarker([-65.05, 37.53], icons.signpost, 'Ruined Tower', '<h1>Ruined Tower</h1>Five centuries ago King Geddes sent his most loyal knight, Martin of Oakdale, to watch over the inhabitants of this troubled land. He also sent his least-loyal knight, to scrub Martin\'s latrines'),
+			createMarker([-70.73, 43.68], icons.signpost, 'Ancient Oak', '<h1>Ancient Oak</h1>Centuries ago bloody rituals in honor of the old gods were conducted here. Locals believe dark forces still haunt this place'),
+			createMarker([-58.79, 30.63], icons.signpost, 'Downwarren', '<h1>Downwarren</h1>Before the war, the inhabitants of this village were known for their intricate lacemaking and artisanal smithery'),
+			createMarker([-54.39, 10.99], icons.signpost, 'Dragonslayer\'s Grotto', '<h1>Dragonslayer\'s Grotto</h1>Underneath this fortress lies a musty, rank cave in which a lost traveler will find nothing but a few fattened leeches - if he\'s lucky. Nevertheless, village elders insist on repeating the legend that gave the grotto its name: that of a legendary dragonslayer said to be buried somewhere deep inside'),
+			createMarker([-48.75, 30.72], icons.signpost, 'Reardon Manor', '<h1>Reardon Manor</h1>Abandoned estate of the once prominent Reardon family, relatives to the royal La Louve dynasty'),
+			createMarker([-50.63, 67.32], icons.signpost, 'Benek', '<h1>Benek</h1>This small village owes its name to its founding elder, who erected the largest windmill the land had ever seen on this spot - thereby providing work for all the village\'s inhabitants'),
+			createMarker([-36.10, 51.68], icons.signpost, 'Toderas', '<h1>Toderas</h1>Village founded by King Griffin of Temeria, the husband of Clarissa of Toussaint. The king had planned to turn Toderas into a large, bustling university city, a sort of Temerian alternative to Oxenfurt, but, as any visitor can quickly attest, his efforts failed utterly'),
+			createMarker([-34.42, 11.69], icons.signpost, 'Lurtch', '<h1>Lurtch</h1>Once the Evves family estate was located here and the area bore the name of Lord Evves\' wife, Mortilanca. When the couple died, their will stipulated their land be turned over to their serfs. The grateful peasants then founded a village of freeholders and named it after their first ealdorman, Lurtch, who had previously served as the Evves family\'s butler'),
+			createMarker([-36.81, -25.97], icons.signpost, 'Lindenvale', '<h1>Lindenvale</h1>One of Velen\'s many impoverished villages, its poverty deepened by war levies and the epidemic that spread after the Nilfgaardians\' arrival'),
+			createMarker([-17.22, 40.17], icons.signpost, 'Marauders\' Bridge', '<h1>Marauders\' Bridge</h1>After the Battle of Velen, marauders swarmed over this bridge in their rush to scavenge the battlefield'),
+			createMarker([-22.92, 71.59], icons.signpost, 'Grotto', '<h1>Grotto</h1>A dark and hostile place which creaks from time to time with unsettling, throaty noises...'),
+	]);
 
 	// Smugglers' Cache
-		var smugglersIcon = L.icon({
-			iconUrl  : '/files/img/icons/smugglers.png',
-			iconSize : [28, 30]
-		});
+	var smugglersGeneric = genericMarkers([
+		// Novigrad
+			[67.37, -33.44],
+			[71.07, -9.14],
+		// S Novigrad
+			[61.17, -84.11],
+		// NW Velen
+			[-58.90, -158.82],
+	], icons.smugglers, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
 
-		var smugglersGeneric = genericMarkers([
-			// Novigrad
-				[67.37, -33.44],
-				[71.07, -9.14],
-			// S Novigrad
-				[61.17, -84.11],
-			// NW Velen
-				[-58.90, -158.82],
-		], smugglersIcon, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
-
-		window.markers['smugglers'] = L.layerGroup($.merge(smugglersGeneric, [
-			// No custom markers needed
-		]));
+	markers.smugglers = L.layerGroup($.merge(smugglersGeneric, [
+		// No custom markers needed
+	]));
 
 	// Spoils of War
-		var spoilsIcon = L.icon({
-			iconUrl  : '/files/img/icons/spoils.png',
-			iconSize : [25, 28]
-		});
-
-		window.markers['spoils'] = L.layerGroup([
-			// NE Velen
-				L.marker([33.91, -68.51], setMarker(spoilsIcon)).bindLabel('Spoils of War').bindPopup('<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'),
-			// NW Velen
-				L.marker([-22.72, -32.04], setMarker(spoilsIcon)).bindLabel('Spoils of War').bindPopup('<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish (lvl 4<span> Drowners</span>'),
-			// SW Velen
-				L.marker([-74.75, -144.93], setMarker(spoilsIcon)).bindLabel('Spoils of War').bindPopup('<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish (lvl 10<span> Drowners</span>)'),
-		]);
+	markers.spoils = L.layerGroup([
+		// NE Velen
+			createMarker([33.91, -68.51], icons.spoils, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'),
+		// NW Velen
+			createMarker([-22.72, -32.04], icons.spoils, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish (lvl 4<span> Drowners</span>'),
+		// SW Velen
+			createMarker([-74.75, -144.93], icons.spoils, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish (lvl 10<span> Drowners</span>)'),
+	]);
 
 	window.allLayers = [
-		window.markers['abandoned'],
-		window.markers['alchemy'],
-		window.markers['armourer'],
-		window.markers['armourerstable'],
-		window.markers['banditcamp'],
-		window.markers['barber'],
-		window.markers['blacksmith'],
-		window.markers['brothel'],
-		window.markers['entrance'],
-		window.markers['grindstone'],
-		window.markers['guarded'],
-		window.markers['gwent'],
-		window.markers['harbor'],
-		window.markers['herbalist'],
-		window.markers['hidden'],
-		window.markers['innkeep'],
-		window.markers['monsterden'],
-		window.markers['monsternest'],
-		window.markers['notice'],
-		window.markers['pid'],
-		window.markers['pop'],
-		window.markers['poi'],
-		window.markers['shopkeeper'],
-		window.markers['signpost'],
-		window.markers['smugglers'],
-		window.markers['spoils']
+		markers.abandoned,
+		markers.alchemy,
+		markers.armourer,
+		markers.armourerstable,
+		markers.banditcamp,
+		markers.barber,
+		markers.blacksmith,
+		markers.brothel,
+		markers.entrance,
+		markers.grindstone,
+		markers.guarded,
+		markers.gwent,
+		markers.harbor,
+		markers.herbalist,
+		markers.hidden,
+		markers.innkeep,
+		markers.monsterden,
+		markers.monsternest,
+		markers.notice,
+		markers.pid,
+		markers.pop,
+		markers.poi,
+		markers.shopkeeper,
+		markers.signpost,
+		markers.smugglers,
+		markers.spoils
 	];
-});
+}());
+

--- a/files/js/mapdata-white_orchard.js
+++ b/files/js/mapdata-white_orchard.js
@@ -163,28 +163,32 @@
 
 	// Place of Power
 		pop: [{
-			coord: [-81.492, -106.699],
+			coords: [[-81.492, -106.699]],
 			label: 'Place of Power',
-			popupTitle: 'Place of Power - Quen'
+			popupTitle: 'Place of Power - Quen',
 			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
 		}, {
-			coord: [-79.703, -52.822],
+			coords: [[-79.703, -52.822]],
 			label: 'Place of Power',
 			popupTitle: 'Place of Power - Yrden',
 			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
-		}, { coord: [-51.536, -130.386],
+		}, {
+			coords: [[-51.536, -130.386]],
 			label: 'Place of Power',
 			popupTitle: 'Place of Power - Axii',
 			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
-		}, { coord: [-34.235, -94.043],
+		}, {
+			coords: [[-34.235, -94.043]],
 			label: 'Place of Power',
 			popupTitle: 'Place of Power - Igni',
 			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
-		}, { coord: [-13.325, -97.559],
+		}, {
+			coords: [[-13.325, -97.559]],
 			label: 'Place of Power',
 			popupTitle: 'Place of Power - Aard',
 			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
-		}, { coord: [-43.771, 0.308],
+		}, {
+			coords: [[-43.771, 0.308]],
 			label: 'Place of Power',
 			popupTitle: 'Place of Power - Quen',
 			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'

--- a/files/js/mapdata-white_orchard.js
+++ b/files/js/mapdata-white_orchard.js
@@ -1,10 +1,11 @@
-$(function()
-{
-	map_path   = 'white_orchard';
-	map_sWest  = L.latLng(-85, -180);
-	map_nEast  = L.latLng(0, 45);
-	map_center = [-65, -65];
-	map_mZoom  = 5;
+$(function() {
+	window.map_path   = 'white_orchard';
+	window.map_sWest  = L.latLng(-85, -180);
+	window.map_nEast  = L.latLng(0, 45);
+	window.map_center = [-65, -65];
+	window.map_mZoom  = 5;
+
+	window.markers = {};
 
 	// Abandoned Site
 		var abandonedIcon = L.icon({
@@ -12,7 +13,7 @@ $(function()
 			iconSize : [30, 30]
 		});
 
-		abandonedMarkers = L.layerGroup(genericMarkers([
+		window.markers['abandoned'] = L.layerGroup(genericMarkers([
 			[-77.786, -48.604],
 			[-65.293, -152.842],
 		], abandonedIcon, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more'));
@@ -23,7 +24,7 @@ $(function()
 			iconSize : [20, 28]
 		});
 
-		alchemyMarkers = L.layerGroup([
+		window.markers['alchemy'] = L.layerGroup([
 //				L.marker([0, 0], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies').bindPopup('<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
 		]);
 
@@ -33,7 +34,7 @@ $(function()
 			iconSize : [24, 34]
 		});
 
-		armourerMarkers = L.layerGroup([
+		window.markers['armourer'] = L.layerGroup([
 				L.marker([-69.069, -88.945], setMarker(armourerIcon)).bindLabel('Amateur Armorer').bindPopup('<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
 		]);
 
@@ -43,7 +44,7 @@ $(function()
 			iconSize : [30, 27]
 		});
 
-		armourerstableMarkers = L.layerGroup(genericMarkers([
+		window.markers['armourerstable'] = L.layerGroup(genericMarkers([
 			[-25.362, -152.539],
 		], armourerstableIcon, 'Armorer\'s Table', '<h1>Armorer\'s Table</h1>Armorer\'s tables grant your gear increased armor for a limited duration'));
 
@@ -53,7 +54,7 @@ $(function()
 			iconSize : [29, 30]
 		});
 
-		banditcampMarkers = L.layerGroup(genericMarkers([
+		window.markers['banditcamp'] = L.layerGroup(genericMarkers([
 			[-81.596, -122.168],
 			[-73.800, -43.418],
 			[-53.678, -157.720],
@@ -68,7 +69,7 @@ $(function()
 			iconSize : [30, 30]
 		});
 
-		barberMarkers = L.layerGroup([]);
+		window.markers['barber'] = L.layerGroup([]);
 
 	// Blacksmith
 		var blacksmithIcon = L.icon({
@@ -76,7 +77,7 @@ $(function()
 			iconSize : [27, 30]
 		});
 
-		blacksmithMarkers = L.layerGroup([
+		window.markers['blacksmith'] = L.layerGroup([
 				L.marker([-26.981, -151.348], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
 		]);
 
@@ -86,7 +87,7 @@ $(function()
 			iconSize : [28, 26]
 		});
 
-		brothelMarkers = L.layerGroup([]);
+		window.markers['brothel'] = L.layerGroup([]);
 
 	// Entrance
 		var entranceIcon = L.icon({
@@ -95,7 +96,7 @@ $(function()
 		});
 
 		// todo, entrance to what?
-		entranceMarkers = L.layerGroup([
+		window.markers['entrance'] = L.layerGroup([
 				L.marker([-79.592, -84.199], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
 				L.marker([-77.897, -75.586], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
 		]);
@@ -106,7 +107,7 @@ $(function()
 			iconSize : [30, 26]
 		});
 
-		grindstoneMarkers = L.layerGroup(genericMarkers([
+		window.markers['grindstone'] = L.layerGroup(genericMarkers([
 			[-68.948, -88.006],
 			[-68.648, -88.206],
 			[-64.624, -155.215],
@@ -127,7 +128,7 @@ $(function()
 			[-74.776, 0.352],
 		], guardedIcon, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
 
-		guardedMarkers = L.layerGroup($.merge(guardedGeneric, [
+		window.markers['guarded'] = L.layerGroup($.merge(guardedGeneric, [
 			// No custom markers needed
 		]));
 
@@ -137,7 +138,7 @@ $(function()
 			iconSize : [24, 30]
 		});
 
-		gwentMarkers = L.layerGroup([
+		window.markers['gwent'] = L.layerGroup([
 				L.marker([-65.946, -81.387], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Gwent Player</h1>Gamble your hard earned coin playing Gwent here. Disappears after progressing through story quests'),
 		]);
 
@@ -147,7 +148,7 @@ $(function()
 			iconSize : [27, 30]
 		});
 
-		harborMarkers = L.layerGroup([]);
+		window.markers['harbor'] = L.layerGroup([]);
 
 	// Herbalist
 		var herbalistIcon = L.icon({
@@ -155,7 +156,7 @@ $(function()
 			iconSize : [25, 28]
 		});
 
-		herbalistMarkers = L.layerGroup([
+		window.markers['herbalist'] = L.layerGroup([
 			L.marker([-66.267, -132.627], setMarker(herbalistIcon)).bindLabel('Herbalist').bindPopup('<h1>Herbalist</h1>Here you can buy alchemy ingredients'),
 			L.marker([-77.542, -49.043], setMarker(herbalistIcon)).bindLabel('Herbalist').bindPopup('<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
 		]);
@@ -174,7 +175,7 @@ $(function()
 			
 		], hiddenIcon, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
 
-		hiddenMarkers = L.layerGroup($.merge(hiddenGeneric, [
+		window.markers['hidden'] = L.layerGroup($.merge(hiddenGeneric, [
 			// No custom markers needed
 		]));
 
@@ -184,7 +185,7 @@ $(function()
 			iconSize : [26, 30]
 		});
 
-		innkeepMarkers = L.layerGroup([
+		window.markers['innkeep'] = L.layerGroup([
 			L.marker([-65.731, -80.068], setMarker(innkeepIcon)).bindLabel('White Orchard Inn').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, and drink. Disappears after progressing through story quests'),
 		]);
 
@@ -194,7 +195,7 @@ $(function()
 			iconSize : [30, 27]
 		});
 
-		monsterdenMarkers = L.layerGroup([]);
+		window.markers['monsterden'] = L.layerGroup([]);
 
 	// Monster Nest
 		var monsternestIcon = L.icon({
@@ -208,7 +209,7 @@ $(function()
 			[-64.206, 9.712],
 		], monsternestIcon, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
 
-		monsternestMarkers = L.layerGroup($.merge(monsternestGeneric, [
+		window.markers['monsternest'] = L.layerGroup($.merge(monsternestGeneric, [
 			// No custom markers needed
 		]));
 
@@ -218,7 +219,7 @@ $(function()
 			iconSize : [23, 28]
 		});
 
-		noticeMarkers = L.layerGroup(genericMarkers([
+		window.markers['notice'] = L.layerGroup(genericMarkers([
 				[-67.643, -89.385],
 		], noticeIcon, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
 
@@ -228,7 +229,7 @@ $(function()
 			iconSize : [24, 34]
 		});
 
-		pidMarkers = L.layerGroup([]);
+		window.markers['pid'] = L.layerGroup([]);
 
 	// Place of Power
 		var popIcon = L.icon({
@@ -237,7 +238,7 @@ $(function()
 		});
 
 		//todo get all place of power types
-		popMarkers = L.layerGroup([
+		window.markers['pop'] = L.layerGroup([
 			L.marker([-81.492, -106.699], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
 			L.marker([-79.703, -52.822], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
 			L.marker([-51.536, -130.386], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Axii</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
@@ -253,7 +254,7 @@ $(function()
 			iconSize : [28, 28]
 		});
 
-		poiMarkers = L.layerGroup([
+		window.markers['poi'] = L.layerGroup([
 			L.marker([-49.611, 7.998], setMarker(poiIcon)).bindLabel('Lootable Battlefield').bindPopup('<h1>Lootable Battlefield</h1>This battlefield can be looted for easy early game coin'),
 		]);
 
@@ -263,7 +264,7 @@ $(function()
 			iconSize : [21, 30]
 		});
 
-		shopkeeperMarkers = L.layerGroup([
+		window.markers['shopkeeper'] = L.layerGroup([
 				L.marker([-66.320, -75.674], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells Gwent cards, crafting supplies, and Temerian: blinders, saddle, saddlebags, armour'),
 				L.marker([-66.338, -155.654], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
 		]);
@@ -274,7 +275,7 @@ $(function()
 			iconSize : [27, 34]
 		});
 
-		signpostMarkers = L.layerGroup([
+		window.markers['signpost'] = L.layerGroup([
 			L.marker([-78.955, -85.869], setMarker(signpostIcon)).bindLabel('Abandoned Village').bindPopup('<h1>Abandoned Village</h1>A few years ago, a group of armed men marched into this settlement. They butchered its inhabitants and burned down their homes. Not a soul has dwelt here since that black and bloody day'),
 			L.marker([-77.916, -109.819], setMarker(signpostIcon)).bindLabel('Broken Bridge').bindPopup('<h1>Broken Bridge</h1>This bridge was destroyed by retreating Temerian troops during the Nilfgaardian attack. It was shoddily built to begin with. Good riddance'),
 			L.marker([-67.136, -72.202], setMarker(signpostIcon)).bindLabel('Woesong Bridge').bindPopup('<h1>Woesong Bridge</h1>So named because of a girl who once would stand on the bridge and sing, waiting for her beloved\'s return'),
@@ -297,7 +298,7 @@ $(function()
 			[-76.720, -31.201],
 		], smugglersIcon, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
 
-		smugglersMarkers = L.layerGroup($.merge(smugglersGeneric, [
+		window.markers['smugglers'] = L.layerGroup($.merge(smugglersGeneric, [
 			// No custom markers needed
 		]));
 
@@ -307,22 +308,36 @@ $(function()
 			iconSize : [25, 28]
 		});
 
-		spoilsMarkers = L.layerGroup(genericMarkers([
+		window.markers['spoils'] = L.layerGroup(genericMarkers([
 			[-12.726, -128.452],
 		], spoilsIcon, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'));
 
-	allLayers = [abandonedMarkers, alchemyMarkers, armourerMarkers, armourerstableMarkers, banditcampMarkers, barberMarkers, blacksmithMarkers, brothelMarkers, entranceMarkers, grindstoneMarkers, guardedMarkers, gwentMarkers, harborMarkers, herbalistMarkers, hiddenMarkers, innkeepMarkers, monsterdenMarkers, monsternestMarkers, noticeMarkers, pidMarkers, popMarkers, poiMarkers, shopkeeperMarkers, signpostMarkers, smugglersMarkers, spoilsMarkers];
+	window.allLayers = [
+		window.markers['abandoned'],
+		window.markers['alchemy'],
+		window.markers['armourer'],
+		window.markers['armourerstable'],
+		window.markers['banditcamp'],
+		window.markers['barber'],
+		window.markers['blacksmith'],
+		window.markers['brothel'],
+		window.markers['entrance'],
+		window.markers['grindstone'],
+		window.markers['guarded'],
+		window.markers['gwent'],
+		window.markers['harbor'],
+		window.markers['herbalist'],
+		window.markers['hidden'],
+		window.markers['innkeep'],
+		window.markers['monsterden'],
+		window.markers['monsternest'],
+		window.markers['notice'],
+		window.markers['pid'],
+		window.markers['pop'],
+		window.markers['poi'],
+		window.markers['shopkeeper'],
+		window.markers['signpost'],
+		window.markers['smugglers'],
+		window.markers['spoils']
+	];
 });
-
-function genericMarkers(cords, icon, label, popup) {
-	var out = [];
-	$.each(cords, function(key, val)
-	{
-		out.push(L.marker(val, setMarker(icon)).bindLabel(label).bindPopup(popup));
-	});
-	return out;
-}
-
-function setMarker(icon, tooltip) {
-	return {icon : icon, riseOnHover : true};
-}

--- a/files/js/mapdata-white_orchard.js
+++ b/files/js/mapdata-white_orchard.js
@@ -1,4 +1,4 @@
-$(function() {
+(function () {
 	window.map_path   = 'white_orchard';
 	window.map_sWest  = L.latLng(-85, -180);
 	window.map_nEast  = L.latLng(0, 45);
@@ -7,337 +7,222 @@ $(function() {
 
 	window.markers = {};
 
-	// Abandoned Site
-		var abandonedIcon = L.icon({
-			iconUrl  : '/files/img/icons/abandoned.png',
-			iconSize : [30, 30]
-		});
+	var markers = window.markers;
+	var icons = window.icons;
 
-		window.markers['abandoned'] = L.layerGroup(genericMarkers([
-			[-77.786, -48.604],
-			[-65.293, -152.842],
-		], abandonedIcon, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more'));
+	// Abandoned Site
+	markers.abandoned = L.layerGroup(genericMarkers([
+		[-77.786, -48.604],
+		[-65.293, -152.842],
+	], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more'));
 
 	// Alchemy Supplies
-		var alchemyIcon = L.icon({
-			iconUrl  : '/files/img/icons/alchemy.png',
-			iconSize : [20, 28]
-		});
-
-		window.markers['alchemy'] = L.layerGroup([
-//				L.marker([0, 0], setMarker(alchemyIcon)).bindLabel('Alchemy Supplies').bindPopup('<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
-		]);
+	markers.alchemy = L.layerGroup([
+		//createMarker([0, 0], icons.alchemy, 'Alchemy Supplies', '<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
+	]);
 
 	// Armourer
-		var armourerIcon = L.icon({
-			iconUrl  : '/files/img/icons/armourer.png',
-			iconSize : [24, 34]
-		});
-
-		window.markers['armourer'] = L.layerGroup([
-				L.marker([-69.069, -88.945], setMarker(armourerIcon)).bindLabel('Amateur Armorer').bindPopup('<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		]);
+	markers.armourer = L.layerGroup([
+			createMarker([-69.069, -88.945], icons.armourer, 'Amateur Armorer', '<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+	]);
 
 	// Armourer's Table
-		var armourerstableIcon = L.icon({
-			iconUrl  : '/files/img/icons/armourerstable.png',
-			iconSize : [30, 27]
-		});
-
-		window.markers['armourerstable'] = L.layerGroup(genericMarkers([
-			[-25.362, -152.539],
-		], armourerstableIcon, 'Armorer\'s Table', '<h1>Armorer\'s Table</h1>Armorer\'s tables grant your gear increased armor for a limited duration'));
+	markers.armourerstable = L.layerGroup(genericMarkers([
+		[-25.362, -152.539],
+	], icons.armourerstable, 'Armorer\'s Table', '<h1>Armorer\'s Table</h1>Armorer\'s tables grant your gear increased armor for a limited duration'));
 
 	// Bandit Camp
-		var banditcampIcon = L.icon({
-			iconUrl  : '/files/img/icons/banditcamp.png',
-			iconSize : [29, 30]
-		});
-
-		window.markers['banditcamp'] = L.layerGroup(genericMarkers([
-			[-81.596, -122.168],
-			[-73.800, -43.418],
-			[-53.678, -157.720],
-			[-34.307, -25.537],
-			[-72.462, -16.699],
-			[-66.000, -19.688],
-		], banditcampIcon, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here'));
+	markers.banditcamp = L.layerGroup(genericMarkers([
+		[-81.596, -122.168],
+		[-73.800, -43.418],
+		[-53.678, -157.720],
+		[-34.307, -25.537],
+		[-72.462, -16.699],
+		[-66.000, -19.688],
+	], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here'));
 
 	// Barber
-		var barberIcon = L.icon({
-			iconUrl  : '/files/img/icons/barber.png',
-			iconSize : [30, 30]
-		});
-
-		window.markers['barber'] = L.layerGroup([]);
+	markers.barber = L.layerGroup([]);
 
 	// Blacksmith
-		var blacksmithIcon = L.icon({
-			iconUrl  : '/files/img/icons/blacksmith.png',
-			iconSize : [27, 30]
-		});
-
-		window.markers['blacksmith'] = L.layerGroup([
-				L.marker([-26.981, -151.348], setMarker(blacksmithIcon)).bindLabel('Amateur Blacksmith').bindPopup('<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-		]);
+	markers.blacksmith = L.layerGroup([
+		createMarker([-26.981, -151.348], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
+	]);
 
 	// Brothel
-		var brothelIcon = L.icon({
-			iconUrl  : '/files/img/icons/brothel.png',
-			iconSize : [28, 26]
-		});
-
-		window.markers['brothel'] = L.layerGroup([]);
+	markers.brothel = L.layerGroup([]);
 
 	// Entrance
-		var entranceIcon = L.icon({
-			iconUrl  : '/files/img/icons/entrance.png',
-			iconSize : [28, 27]
-		});
-
-		// todo, entrance to what?
-		window.markers['entrance'] = L.layerGroup([
-				L.marker([-79.592, -84.199], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-				L.marker([-77.897, -75.586], setMarker(entranceIcon)).bindLabel('Entrance').bindPopup('<h1>Entrance</h1>Entrance to cave or ruins'),
-		]);
+	// todo, entrance to what?
+	markers.entrance = L.layerGroup([
+		createMarker([-79.592, -84.199], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+		createMarker([-77.897, -75.586], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
+	]);
 
 	// Grindstone
-		var grindstoneIcon = L.icon({
-			iconUrl  : '/files/img/icons/grindstone.png',
-			iconSize : [30, 26]
-		});
-
-		window.markers['grindstone'] = L.layerGroup(genericMarkers([
-			[-68.948, -88.006],
-			[-68.648, -88.206],
-			[-64.624, -155.215],
-			[-26.902, -149.941],
-		], grindstoneIcon, 'Grindstone', '<h1>Grindstone</h1>A blade sharpened here will deal more damage'));
+	markers.grindstone = L.layerGroup(genericMarkers([
+		[-68.948, -88.006],
+		[-68.648, -88.206],
+		[-64.624, -155.215],
+		[-26.902, -149.941],
+	], icons.grindstone, 'Grindstone', '<h1>Grindstone</h1>A blade sharpened here will deal more damage'));
 
 	// Guarded Treasure
-		var guardedIcon = L.icon({
-			iconUrl  : '/files/img/icons/guarded.png',
-			iconSize : [23, 34]
-		});
+	var guardedGeneric = genericMarkers([
+		[-74.914, -59.766],
+		[-48.517, -167.695],
+		[-29.645, -96.943],
+		[-27.333, -134.077],
+		[-74.776, 0.352],
+	], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
 
-		var guardedGeneric = genericMarkers([
-			[-74.914, -59.766],
-			[-48.517, -167.695],
-			[-29.645, -96.943],
-			[-27.333, -134.077],
-			[-74.776, 0.352],
-		], guardedIcon, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
-
-		window.markers['guarded'] = L.layerGroup($.merge(guardedGeneric, [
-			// No custom markers needed
-		]));
+	markers.guarded = L.layerGroup($.merge(guardedGeneric, [
+		// No custom markers needed
+	]));
 
 	// Gwent Player
-		var gwentIcon = L.icon({
-			iconUrl  : '/files/img/icons/gwent.png',
-			iconSize : [24, 30]
-		});
-
-		window.markers['gwent'] = L.layerGroup([
-				L.marker([-65.946, -81.387], setMarker(gwentIcon)).bindLabel('Gwent Player').bindPopup('<h1>Gwent Player</h1>Gamble your hard earned coin playing Gwent here. Disappears after progressing through story quests'),
-		]);
+	markers.gwent = L.layerGroup([
+		createMarker([-65.946, -81.387], icons.gwent, 'Gwent Player', '<h1>Gwent Player</h1>Gamble your hard earned coin playing Gwent here. Disappears after progressing through story quests'),
+	]);
 
 	// Harbor
-		var harborIcon = L.icon({
-			iconUrl  : '/files/img/icons/harbor.png',
-			iconSize : [27, 30]
-		});
-
-		window.markers['harbor'] = L.layerGroup([]);
+	markers.harbor = L.layerGroup([]);
 
 	// Herbalist
-		var herbalistIcon = L.icon({
-			iconUrl  : '/files/img/icons/herbalist.png',
-			iconSize : [25, 28]
-		});
-
-		window.markers['herbalist'] = L.layerGroup([
-			L.marker([-66.267, -132.627], setMarker(herbalistIcon)).bindLabel('Herbalist').bindPopup('<h1>Herbalist</h1>Here you can buy alchemy ingredients'),
-			L.marker([-77.542, -49.043], setMarker(herbalistIcon)).bindLabel('Herbalist').bindPopup('<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
-		]);
+	markers.herbalist = L.layerGroup([
+		createMarker([-66.267, -132.627], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>Here you can buy alchemy ingredients'),
+		createMarker([-77.542, -49.043], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
+	]);
 
 
 	// Hidden Treasure
-		var hiddenIcon = L.icon({
-			iconUrl  : '/files/img/icons/hidden.png',
-			iconSize : [23, 34]
-		});
+	var hiddenGeneric = genericMarkers([
+		[-47.220, -111.006],
+		[-39.028, -56.865],
+		[-28.613, -42.188],
+		
+	], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
 
-		var hiddenGeneric = genericMarkers([
-			[-47.220, -111.006],
-			[-39.028, -56.865],
-			[-28.613, -42.188],
-			
-		], hiddenIcon, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
-
-		window.markers['hidden'] = L.layerGroup($.merge(hiddenGeneric, [
-			// No custom markers needed
-		]));
+	markers.hidden = L.layerGroup($.merge(hiddenGeneric, [
+		// No custom markers needed
+	]));
 
 	// Innkeep
-		var innkeepIcon = L.icon({
-			iconUrl  : '/files/img/icons/tavern.png',
-			iconSize : [26, 30]
-		});
-
-		window.markers['innkeep'] = L.layerGroup([
-			L.marker([-65.731, -80.068], setMarker(innkeepIcon)).bindLabel('White Orchard Inn').bindPopup('<h1>Innkeep</h1>Sells Gwent cards, and drink. Disappears after progressing through story quests'),
-		]);
+	markers.innkeep = L.layerGroup([
+		createMarker([-65.731, -80.068], icons.innkeep, 'White Orchard Inn', '<h1>Innkeep</h1>Sells Gwent cards, and drink. Disappears after progressing through story quests'),
+	]);
 
 	// Monster Den
-		var monsterdenIcon = L.icon({
-			iconUrl  : '/files/img/icons/monsterden.png',
-			iconSize : [30, 27]
-		});
-
-		window.markers['monsterden'] = L.layerGroup([]);
+	markers.monsterden = L.layerGroup([]);
 
 	// Monster Nest
-		var monsternestIcon = L.icon({
-			iconUrl  : '/files/img/icons/monsternest.png',
-			iconSize : [23, 30]
-		});
+	var monsternestGeneric = genericMarkers([
+		[-14.264, -95.625],
+		[-45.027, -0.308],
+		[-64.206, 9.712],
+	], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
 
-		var monsternestGeneric = genericMarkers([
-			[-14.264, -95.625],
-			[-45.027, -0.308],
-			[-64.206, 9.712],
-		], monsternestIcon, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
-
-		window.markers['monsternest'] = L.layerGroup($.merge(monsternestGeneric, [
-			// No custom markers needed
-		]));
+	markers.monsternest = L.layerGroup($.merge(monsternestGeneric, [
+		// No custom markers needed
+	]));
 
 	// Notice Board
-		var noticeIcon = L.icon({
-			iconUrl  : '/files/img/icons/notice.png',
-			iconSize : [23, 28]
-		});
-
-		window.markers['notice'] = L.layerGroup(genericMarkers([
-				[-67.643, -89.385],
-		], noticeIcon, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
+	markers.notice = L.layerGroup(genericMarkers([
+			[-67.643, -89.385],
+	], icons.notice, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
 
 	// Person in Distress
-		var pidIcon = L.icon({
-			iconUrl  : '/files/img/icons/pid.png',
-			iconSize : [24, 34]
-		});
-
-		window.markers['pid'] = L.layerGroup([]);
+	markers.pid = L.layerGroup([]);
 
 	// Place of Power
-		var popIcon = L.icon({
-			iconUrl  : '/files/img/icons/pop.png',
-			iconSize : [27, 30]
-		});
-
-		//todo get all place of power types
-		window.markers['pop'] = L.layerGroup([
-			L.marker([-81.492, -106.699], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			L.marker([-79.703, -52.822], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			L.marker([-51.536, -130.386], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Axii</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			L.marker([-34.235, -94.043], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Igni</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			L.marker([-13.325, -97.559], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Aard</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-			L.marker([-43.771, 0.308], setMarker(popIcon)).bindLabel('Place of Power').bindPopup('<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-				
-		]);
+	//todo get all place of power types
+	markers.pop = L.layerGroup([
+		createMarker([-81.492, -106.699], icons.pop, 'Place of Power', '<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+		createMarker([-79.703, -52.822], icons.pop, 'Place of Power', '<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+		createMarker([-51.536, -130.386], icons.pop, 'Place of Power', '<h1>Place of Power - Axii</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+		createMarker([-34.235, -94.043], icons.pop, 'Place of Power', '<h1>Place of Power - Igni</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+		createMarker([-13.325, -97.559], icons.pop, 'Place of Power', '<h1>Place of Power - Aard</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+		createMarker([-43.771, 0.308], icons.pop, 'Place of Power', '<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
+	]);
 
 	// Point of Interest
-		var poiIcon = L.icon({
-			iconUrl  : '/files/img/icons/poi.png',
-			iconSize : [28, 28]
-		});
-
-		window.markers['poi'] = L.layerGroup([
-			L.marker([-49.611, 7.998], setMarker(poiIcon)).bindLabel('Lootable Battlefield').bindPopup('<h1>Lootable Battlefield</h1>This battlefield can be looted for easy early game coin'),
-		]);
+	markers.poi = L.layerGroup([
+		createMarker([-49.611, 7.998], icons.poi, 'Lootable Battlefield', '<h1>Lootable Battlefield</h1>This battlefield can be looted for easy early game coin'),
+	]);
 
 	// Shopkeeper
-		var shopkeeperIcon = L.icon({
-			iconUrl  : '/files/img/icons/merchant.png',
-			iconSize : [21, 30]
-		});
-
-		window.markers['shopkeeper'] = L.layerGroup([
-				L.marker([-66.320, -75.674], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells Gwent cards, crafting supplies, and Temerian: blinders, saddle, saddlebags, armour'),
-				L.marker([-66.338, -155.654], setMarker(shopkeeperIcon)).bindLabel('Shopkeeper').bindPopup('<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
-		]);
+	markers.shopkeeper = L.layerGroup([
+		createMarker([-66.320, -75.674], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells Gwent cards, crafting supplies, and Temerian: blinders, saddle, saddlebags, armour'),
+		createMarker([-66.338, -155.654], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
+	]);
 
 	// Sign Post
-		var signpostIcon = L.icon({
-			iconUrl  : '/files/img/icons/fasttravel.png',
-			iconSize : [27, 34]
-		});
-
-		window.markers['signpost'] = L.layerGroup([
-			L.marker([-78.955, -85.869], setMarker(signpostIcon)).bindLabel('Abandoned Village').bindPopup('<h1>Abandoned Village</h1>A few years ago, a group of armed men marched into this settlement. They butchered its inhabitants and burned down their homes. Not a soul has dwelt here since that black and bloody day'),
-			L.marker([-77.916, -109.819], setMarker(signpostIcon)).bindLabel('Broken Bridge').bindPopup('<h1>Broken Bridge</h1>This bridge was destroyed by retreating Temerian troops during the Nilfgaardian attack. It was shoddily built to begin with. Good riddance'),
-			L.marker([-67.136, -72.202], setMarker(signpostIcon)).bindLabel('Woesong Bridge').bindPopup('<h1>Woesong Bridge</h1>So named because of a girl who once would stand on the bridge and sing, waiting for her beloved\'s return'),
-			L.marker([-65.440, -141.855], setMarker(signpostIcon)).bindLabel('Sawmill').bindPopup('<h1>Sawmill</h1>White Orchard is famous not only for its premium fruit, but also for the top-quality, furniture-grade lumber harvested from the Vulpine Woods'),
-			L.marker([-47.339, -89.912], setMarker(signpostIcon)).bindLabel('Mill').bindPopup('<h1>Mill</h1>Carts haul grain from all the surrounding villages to White Orchard\'s mill'),
-			L.marker([-20.468, -153.281], setMarker(signpostIcon)).bindLabel('Nilfgaardian Garrison').bindPopup('<h1>Nilfgaardian Garrison</h1>This strategic point guards White Orchard\'s main river crossing. Nilfgaardian troops have taken it over'),
-			L.marker([-46.073, -13.271], setMarker(signpostIcon)).bindLabel('Cackler Bridge').bindPopup('<h1>Cackler Bridge</h1>Bridge named in honor of a woman who went mad from unfulfilled love. After her heart snapped, she spent all her days running up and down this bridge while laughing hysterically'),
-			L.marker([-63.015, -4.482], setMarker(signpostIcon)).bindLabel('Crossroads').bindPopup('<h1>Crossroads</h1>The road splits here. One fork leads to Vizima, the other to Novigrad'),
-			L.marker([-68.106, -37.266], setMarker(signpostIcon)).bindLabel('Ford').bindPopup('<h1>Ford</h1>Before the war, merchants and travelers would cross the river here. Now only Nilfgaardian soldiers traverse this path'),
-			L.marker([-71.413, 1.230], setMarker(signpostIcon)).bindLabel('Ransacked Village').bindPopup('<h1>Ransacked Village</h1>A band of soldiers attacked this village early one morning. They slaughtered most of the villagers in their beds, and the lucky few who fled to the woods in time had nothing left to return to'),
-		]);
+	markers.signpost = L.layerGroup([
+		createMarker([-78.955, -85.869], icons.signpost, 'Abandoned Village', '<h1>Abandoned Village</h1>A few years ago, a group of armed men marched into this settlement. They butchered its inhabitants and burned down their homes. Not a soul has dwelt here since that black and bloody day'),
+		createMarker([-77.916, -109.819], icons.signpost, 'Broken Bridge', '<h1>Broken Bridge</h1>This bridge was destroyed by retreating Temerian troops during the Nilfgaardian attack. It was shoddily built to begin with. Good riddance'),
+		createMarker([-67.136, -72.202], icons.signpost, 'Woesong Bridge', '<h1>Woesong Bridge</h1>So named because of a girl who once would stand on the bridge and sing, waiting for her beloved\'s return'),
+		createMarker([-65.440, -141.855], icons.signpost, 'Sawmill', '<h1>Sawmill</h1>White Orchard is famous not only for its premium fruit, but also for the top-quality, furniture-grade lumber harvested from the Vulpine Woods'),
+		createMarker([-47.339, -89.912], icons.signpost, 'Mill', '<h1>Mill</h1>Carts haul grain from all the surrounding villages to White Orchard\'s mill'),
+		createMarker([-20.468, -153.281], icons.signpost, 'Nilfgaardian Garrison', '<h1>Nilfgaardian Garrison</h1>This strategic point guards White Orchard\'s main river crossing. Nilfgaardian troops have taken it over'),
+		createMarker([-46.073, -13.271], icons.signpost, 'Cackler Bridge', '<h1>Cackler Bridge</h1>Bridge named in honor of a woman who went mad from unfulfilled love. After her heart snapped, she spent all her days running up and down this bridge while laughing hysterically'),
+		createMarker([-63.015, -4.482], icons.signpost, 'Crossroads', '<h1>Crossroads</h1>The road splits here. One fork leads to Vizima, the other to Novigrad'),
+		createMarker([-68.106, -37.266], icons.signpost, 'Ford', '<h1>Ford</h1>Before the war, merchants and travelers would cross the river here. Now only Nilfgaardian soldiers traverse this path'),
+		createMarker([-71.413, 1.230], icons.signpost, 'Ransacked Village', '<h1>Ransacked Village</h1>A band of soldiers attacked this village early one morning. They slaughtered most of the villagers in their beds, and the lucky few who fled to the woods in time had nothing left to return to'),
+	]);
 
 	// Smugglers' Cache
-		var smugglersIcon = L.icon({
-			iconUrl  : '/files/img/icons/smugglers.png',
-			iconSize : [28, 30]
-		});
+	var smugglersGeneric = genericMarkers([
+		[-76.720, -31.201],
+	], icons.smugglers, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
 
-		var smugglersGeneric = genericMarkers([
-			[-76.720, -31.201],
-		], smugglersIcon, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
-
-		window.markers['smugglers'] = L.layerGroup($.merge(smugglersGeneric, [
-			// No custom markers needed
-		]));
+	markers.smugglers = L.layerGroup($.merge(smugglersGeneric, [
+		// No custom markers needed
+	]));
 
 	// Spoils of War
-		var spoilsIcon = L.icon({
-			iconUrl  : '/files/img/icons/spoils.png',
-			iconSize : [25, 28]
-		});
-
-		window.markers['spoils'] = L.layerGroup(genericMarkers([
-			[-12.726, -128.452],
-		], spoilsIcon, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'));
+	markers.spoils = L.layerGroup(genericMarkers([
+		[-12.726, -128.452],
+	], icons.spoils, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'));
 
 	window.allLayers = [
-		window.markers['abandoned'],
-		window.markers['alchemy'],
-		window.markers['armourer'],
-		window.markers['armourerstable'],
-		window.markers['banditcamp'],
-		window.markers['barber'],
-		window.markers['blacksmith'],
-		window.markers['brothel'],
-		window.markers['entrance'],
-		window.markers['grindstone'],
-		window.markers['guarded'],
-		window.markers['gwent'],
-		window.markers['harbor'],
-		window.markers['herbalist'],
-		window.markers['hidden'],
-		window.markers['innkeep'],
-		window.markers['monsterden'],
-		window.markers['monsternest'],
-		window.markers['notice'],
-		window.markers['pid'],
-		window.markers['pop'],
-		window.markers['poi'],
-		window.markers['shopkeeper'],
-		window.markers['signpost'],
-		window.markers['smugglers'],
-		window.markers['spoils']
+		markers.abandoned,
+		markers.alchemy,
+		markers.armourer,
+		markers.armourerstable,
+		markers.banditcamp,
+		markers.barber,
+		markers.blacksmith,
+		markers.brothel,
+		markers.entrance,
+		markers.grindstone,
+		markers.guarded,
+		markers.gwent,
+		markers.harbor,
+		markers.herbalist,
+		markers.hidden,
+		markers.innkeep,
+		markers.monsterden,
+		markers.monsternest,
+		markers.notice,
+		markers.pid,
+		markers.pop,
+		markers.poi,
+		markers.shopkeeper,
+		markers.signpost,
+		markers.smugglers,
+		markers.spoils
 	];
-});
+
+	function genericMarkers(cords, icon, label, popup) {
+		var out = [];
+		$.each(cords, function(key, val)
+		{
+			out.push(L.marker(val, setMarker(icon)).bindLabel(label).bindPopup(popup));
+		});
+		return out;
+	}
+
+	function setMarker(icon, tooltip) {
+		return {icon : icon, riseOnHover : true};
+	}
+}());

--- a/files/js/mapdata-white_orchard.js
+++ b/files/js/mapdata-white_orchard.js
@@ -5,184 +5,266 @@
 	window.map_center = [-65, -65];
 	window.map_mZoom  = 5;
 
-	window.markers = {};
-
-	var markers = window.markers;
-	var icons = window.icons;
-
+	processData({
 	// Abandoned Site
-	markers.abandoned = L.layerGroup(genericMarkers([
-		[-77.786, -48.604],
-		[-65.293, -152.842],
-	], icons.abandoned, 'Abandoned Site', '<h1>Abandoned Site</h1>A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more'));
+		abandoned: [{
+			coords: [
+				[-77.786, -48.604],
+				[-65.293, -152.842]
+			],
+			label: 'Abandoned Site',
+			popup: 'A place abandoned due to monster or bandit attacks. Once the danger is eliminated, it will fill with life once more'
+		}],
 
 	// Alchemy Supplies
-	markers.alchemy = L.layerGroup([
-		//createMarker([0, 0], icons.alchemy, 'Alchemy Supplies', '<h1>Alchemy Supplies</h1>Here you can buy alchemy ingredients'),
-	]);
+		alchemy: [],
 
 	// Armourer
-	markers.armourer = L.layerGroup([
-			createMarker([-69.069, -88.945], icons.armourer, 'Amateur Armorer', '<h1>Amateur Armorer</h1>Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-	]);
+		armourer: [{
+			coords: [[-69.069, -88.945]],
+			label: 'Amateur Armorer',
+			popup: 'Here you can craft armor, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}],
 
 	// Armourer's Table
-	markers.armourerstable = L.layerGroup(genericMarkers([
-		[-25.362, -152.539],
-	], icons.armourerstable, 'Armorer\'s Table', '<h1>Armorer\'s Table</h1>Armorer\'s tables grant your gear increased armor for a limited duration'));
+		armourerstable: [{
+			coords: [
+				[-25.362, -152.539],
+			],
+			label: "Armorer's Table",
+			popup: "Armorer's tables grant your gear increased armor for a limited duration"
+		}],
 
 	// Bandit Camp
-	markers.banditcamp = L.layerGroup(genericMarkers([
-		[-81.596, -122.168],
-		[-73.800, -43.418],
-		[-53.678, -157.720],
-		[-34.307, -25.537],
-		[-72.462, -16.699],
-		[-66.000, -19.688],
-	], icons.banditcamp, 'Bandit Camp', '<h1>Bandit Camp</h1>A group of dangerous bandits have made camp here'));
+		banditcamp: [{
+			coords: [
+				[-81.596, -122.168],
+				[-73.800, -43.418],
+				[-53.678, -157.720],
+				[-34.307, -25.537],
+				[-72.462, -16.699],
+				[-66.000, -19.688]
+			],
+			label: 'Bandit Camp',
+			popup: 'A group of dangerous bandits have made camp here'
+		}],
 
 	// Barber
-	markers.barber = L.layerGroup([]);
+		barber: [],
 
 	// Blacksmith
-	markers.blacksmith = L.layerGroup([
-		createMarker([-26.981, -151.348], icons.blacksmith, 'Amateur Blacksmith', '<h1>Amateur Blacksmith</h1>Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'),
-	]);
+		blacksmith: [{
+			coords: [[-26.981, -151.348]],
+			label: 'Amateur Blacksmith',
+			popup: 'Here you can craft weapons, repair damaged equipment, dismantle equipment for parts or remove upgrades from sockets'
+		}],
 
 	// Brothel
-	markers.brothel = L.layerGroup([]);
+		brothel: [],
 
 	// Entrance
-	// todo, entrance to what?
-	markers.entrance = L.layerGroup([
-		createMarker([-79.592, -84.199], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-		createMarker([-77.897, -75.586], icons.entrance, 'Entrance', '<h1>Entrance</h1>Entrance to cave or ruins'),
-	]);
+		entrance: [{
+			coords: [[-79.592, -84.199]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins',
+		}, {
+			coords: [[-77.897, -75.586]],
+			label: 'Entrance',
+			popup: 'Entrance to cave or ruins'
+		}],
 
 	// Grindstone
-	markers.grindstone = L.layerGroup(genericMarkers([
-		[-68.948, -88.006],
-		[-68.648, -88.206],
-		[-64.624, -155.215],
-		[-26.902, -149.941],
-	], icons.grindstone, 'Grindstone', '<h1>Grindstone</h1>A blade sharpened here will deal more damage'));
+		grindstone: [{
+			coords: [
+				[-68.948, -88.006],
+				[-68.648, -88.206],
+				[-64.624, -155.215],
+				[-26.902, -149.941]
+			],
+			label: 'Grindstone',
+			popup: 'A blade sharpened here will deal more damage'
+		}],
 
 	// Guarded Treasure
-	var guardedGeneric = genericMarkers([
-		[-74.914, -59.766],
-		[-48.517, -167.695],
-		[-29.645, -96.943],
-		[-27.333, -134.077],
-		[-74.776, 0.352],
-	], icons.guarded, 'Guarded Treasure', '<h1>Guarded Treasure</h1>A particularly powerful monster guards a valuable cache here');
-
-	markers.guarded = L.layerGroup($.merge(guardedGeneric, [
-		// No custom markers needed
-	]));
+		guarded: [{
+			coords: [
+				[-74.914, -59.766],
+				[-48.517, -167.695],
+				[-29.645, -96.943],
+				[-27.333, -134.077],
+				[-74.776, 0.352]
+			],
+			label: 'Guarded Treasure',
+			popup: 'A particularly powerful monster guards a valuable cache here'
+		}],
 
 	// Gwent Player
-	markers.gwent = L.layerGroup([
-		createMarker([-65.946, -81.387], icons.gwent, 'Gwent Player', '<h1>Gwent Player</h1>Gamble your hard earned coin playing Gwent here. Disappears after progressing through story quests'),
-	]);
+		gwent: [{
+			coords: [[-65.946, -81.387]],
+			label: 'Gwent Player',
+			popup: 'Gamble your hard earned coin playing Gwent here. Disappears after progressing through story quests'
+		}],
 
-	// Harbor
-	markers.harbor = L.layerGroup([]);
+		harbor: [],
 
 	// Herbalist
-	markers.herbalist = L.layerGroup([
-		createMarker([-66.267, -132.627], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>Here you can buy alchemy ingredients'),
-		createMarker([-77.542, -49.043], icons.herbalist, 'Herbalist', '<h1>Herbalist</h1>This merchant appears after liberating the area. Here you can buy alchemy ingredients'),
-	]);
-
+		herbalist: [{
+			coords: [[-66.267, -132.627]],
+			label: 'Herbalist',
+			popup: 'Here you can buy alchemy ingredients'
+		}, {
+			coords: [[-77.542, -49.043]],
+			label: 'Herbalist',
+			popup: 'This merchant appears after liberating the area. Here you can buy alchemy ingredients'
+		}],
 
 	// Hidden Treasure
-	var hiddenGeneric = genericMarkers([
-		[-47.220, -111.006],
-		[-39.028, -56.865],
-		[-28.613, -42.188],
-		
-	], icons.hidden, 'Hidden Treasure', '<h1>Hidden Treasure</h1>A hidden cache of valuable goods');
-
-	markers.hidden = L.layerGroup($.merge(hiddenGeneric, [
-		// No custom markers needed
-	]));
+		hidden: [{
+			coords: [
+				[-47.220, -111.006],
+				[-39.028, -56.865],
+				[-28.613, -42.188]
+			],
+			label: 'Hidden Treasure',
+			popup: 'A hidden cache of valuable goods'
+		}],
 
 	// Innkeep
-	markers.innkeep = L.layerGroup([
-		createMarker([-65.731, -80.068], icons.innkeep, 'White Orchard Inn', '<h1>Innkeep</h1>Sells Gwent cards, and drink. Disappears after progressing through story quests'),
-	]);
+		innkeep: [{
+			coords: [[-65.731, -80.068]],
+			label: 'White Orchard Inn',
+			popupTitle: 'Innkeep',
+			popup: 'Sells Gwent cards, and drink. Disappears after progressing through story quests'
+		}],
 
 	// Monster Den
-	markers.monsterden = L.layerGroup([]);
+		monsterden: [],
 
 	// Monster Nest
-	var monsternestGeneric = genericMarkers([
-		[-14.264, -95.625],
-		[-45.027, -0.308],
-		[-64.206, 9.712],
-	], icons.monsternest, 'Monster Nest', '<h1>Monster Nest</h1>Destroy monster nests with Grapeshot or Dancing Star bombs');
-
-	markers.monsternest = L.layerGroup($.merge(monsternestGeneric, [
-		// No custom markers needed
-	]));
+		monsternest: [{
+			coords: [
+				[-14.264, -95.625],
+				[-45.027, -0.308],
+				[-64.206, 9.712]
+			],
+			label: 'Monster Nest',
+			popup: 'Destroy monster nests with Grapeshot or Dancing Star bombs'
+		}],
 
 	// Notice Board
-	markers.notice = L.layerGroup(genericMarkers([
-		[-67.643, -89.385],
-	], icons.notice, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
+		notice: [{
+			coords: [[-67.643, -89.385]],
+			label: 'Notice Board',
+			popup: 'Here you can find monster contracts and announcements about matters of local concern'
+		}],
 
 	// Person in Distress
-	markers.pid = L.layerGroup([]);
+		pid: [],
 
 	// Place of Power
-	//todo get all place of power types
-	markers.pop = L.layerGroup([
-		createMarker([-81.492, -106.699], icons.pop, 'Place of Power', '<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-		createMarker([-79.703, -52.822], icons.pop, 'Place of Power', '<h1>Place of Power - Yrden</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-		createMarker([-51.536, -130.386], icons.pop, 'Place of Power', '<h1>Place of Power - Axii</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-		createMarker([-34.235, -94.043], icons.pop, 'Place of Power', '<h1>Place of Power - Igni</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-		createMarker([-13.325, -97.559], icons.pop, 'Place of Power', '<h1>Place of Power - Aard</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-		createMarker([-43.771, 0.308], icons.pop, 'Place of Power', '<h1>Place of Power - Quen</h1>Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'),
-	]);
+		pop: [{
+			coord: [-81.492, -106.699],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Quen'
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, {
+			coord: [-79.703, -52.822],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Yrden',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, { coord: [-51.536, -130.386],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Axii',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, { coord: [-34.235, -94.043],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Igni',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, { coord: [-13.325, -97.559],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Aard',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}, { coord: [-43.771, 0.308],
+			label: 'Place of Power',
+			popupTitle: 'Place of Power - Quen',
+			popup: 'Draw from a Place of Power to gain a temporary bonus. The first time you draw from any Place of Power, you also receive 1 Ability Point'
+		}],
 
 	// Point of Interest
-	markers.poi = L.layerGroup([
-		createMarker([-49.611, 7.998], icons.poi, 'Lootable Battlefield', '<h1>Lootable Battlefield</h1>This battlefield can be looted for easy early game coin'),
-	]);
+		poi: [{
+			coords: [[-49.611, 7.998]],
+			label: 'Lootable Battlefield',
+			popup: 'This battlefield can be looted for easy early game coin'
+		}],
 
 	// Shopkeeper
-	markers.shopkeeper = L.layerGroup([
-		createMarker([-66.320, -75.674], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells Gwent cards, crafting supplies, and Temerian: blinders, saddle, saddlebags, armour'),
-		createMarker([-66.338, -155.654], icons.shopkeeper, 'Shopkeeper', '<h1>Shopkeeper</h1>Sells runestones, alchemy supplies and food'),
-	]);
+		shopkeeper: [{
+			coords: [[-66.320, -75.674]],
+			label: 'Shopkeeper',
+			popup: 'Sells Gwent cards, crafting supplies, and Temerian: blinders, saddle, saddlebags, armour',
+		}, {
+			coords: [[-66.338, -155.654]],
+			label: 'Shopkeeper',
+			popup: 'Sells runestones, alchemy supplies and food',
+		}],
 
 	// Sign Post
-	markers.signpost = L.layerGroup([
-		createMarker([-78.955, -85.869], icons.signpost, 'Abandoned Village', '<h1>Abandoned Village</h1>A few years ago, a group of armed men marched into this settlement. They butchered its inhabitants and burned down their homes. Not a soul has dwelt here since that black and bloody day'),
-		createMarker([-77.916, -109.819], icons.signpost, 'Broken Bridge', '<h1>Broken Bridge</h1>This bridge was destroyed by retreating Temerian troops during the Nilfgaardian attack. It was shoddily built to begin with. Good riddance'),
-		createMarker([-67.136, -72.202], icons.signpost, 'Woesong Bridge', '<h1>Woesong Bridge</h1>So named because of a girl who once would stand on the bridge and sing, waiting for her beloved\'s return'),
-		createMarker([-65.440, -141.855], icons.signpost, 'Sawmill', '<h1>Sawmill</h1>White Orchard is famous not only for its premium fruit, but also for the top-quality, furniture-grade lumber harvested from the Vulpine Woods'),
-		createMarker([-47.339, -89.912], icons.signpost, 'Mill', '<h1>Mill</h1>Carts haul grain from all the surrounding villages to White Orchard\'s mill'),
-		createMarker([-20.468, -153.281], icons.signpost, 'Nilfgaardian Garrison', '<h1>Nilfgaardian Garrison</h1>This strategic point guards White Orchard\'s main river crossing. Nilfgaardian troops have taken it over'),
-		createMarker([-46.073, -13.271], icons.signpost, 'Cackler Bridge', '<h1>Cackler Bridge</h1>Bridge named in honor of a woman who went mad from unfulfilled love. After her heart snapped, she spent all her days running up and down this bridge while laughing hysterically'),
-		createMarker([-63.015, -4.482], icons.signpost, 'Crossroads', '<h1>Crossroads</h1>The road splits here. One fork leads to Vizima, the other to Novigrad'),
-		createMarker([-68.106, -37.266], icons.signpost, 'Ford', '<h1>Ford</h1>Before the war, merchants and travelers would cross the river here. Now only Nilfgaardian soldiers traverse this path'),
-		createMarker([-71.413, 1.230], icons.signpost, 'Ransacked Village', '<h1>Ransacked Village</h1>A band of soldiers attacked this village early one morning. They slaughtered most of the villagers in their beds, and the lucky few who fled to the woods in time had nothing left to return to'),
-	]);
+		signpost: [{
+			coords: [[-78.955, -85.869]],
+			label: 'Abandoned Village',
+			popup: 'A few years ago, a group of armed men marched into this settlement. They butchered its inhabitants and burned down their homes. Not a soul has dwelt here since that black and bloody day'
+		}, {
+			coords: [[-77.916, -109.819]],
+			label: 'Broken Bridge',
+			popup: 'This bridge was destroyed by retreating Temerian troops during the Nilfgaardian attack. It was shoddily built to begin with. Good riddance'
+		}, {
+			coords: [[-67.136, -72.202]],
+			label: 'Woesong Bridge',
+			popup: "So named because of a girl who once would stand on the bridge and sing, waiting for her beloved's return"
+		}, {
+			coords: [[-65.440, -141.855]],
+			label: 'Sawmill',
+			popup: 'White Orchard is famous not only for its premium fruit, but also for the top-quality, furniture-grade lumber harvested from the Vulpine Woods'
+		}, {
+			coords: [[-47.339, -89.912]],
+			label: 'Mill',
+			popup: "Carts haul grain from all the surrounding villages to White Orchard's mill"
+		}, {
+			coords: [[-20.468, -153.281]],
+			label: 'Nilfgaardian Garrison',
+			popup: "This strategic point guards White Orchard's main river crossing. Nilfgaardian troops have taken it over"
+		}, {
+			coords: [[-46.073, -13.271]],
+			label: 'Cackler Bridge',
+			popup: 'Bridge named in honor of a woman who went mad from unfulfilled love. After her heart snapped, she spent all her days running up and down this bridge while laughing hysterically'
+		}, {
+			coords: [[-63.015, -4.482]],
+			label: 'Crossroads',
+			popup: 'The road splits here. One fork leads to Vizima, the other to Novigrad'
+		}, {
+			coords: [[-68.106, -37.266]],
+			label: 'Ford',
+			popup: 'Before the war, merchants and travelers would cross the river here. Now only Nilfgaardian soldiers traverse this path'
+		}, {
+			coords: [[-71.413, 1.230]],
+			label: 'Ransacked Village',
+			popup: 'A band of soldiers attacked this village early one morning. They slaughtered most of the villagers in their beds, and the lucky few who fled to the woods in time had nothing left to return to'
+		}],
 
 	// Smugglers' Cache
-	var smugglersGeneric = genericMarkers([
-		[-76.720, -31.201],
-	], icons.smugglers, 'Smuggler\'s Cache', '<h1>Smuggler\'s Cache</h1>Smuggled goods have been hidden here');
-
-	markers.smugglers = L.layerGroup($.merge(smugglersGeneric, [
-		// No custom markers needed
-	]));
+		smugglers: [{
+			coords: [[-76.720, -31.201]],
+			label: "Smugglers' Cache",
+			popup: 'Smuggled goods have been hidden here'
+		}],
 
 	// Spoils of War
-	markers.spoils = L.layerGroup(genericMarkers([
-		[-12.726, -128.452],
-	], icons.spoils, 'Spoils of War', '<h1>Spoils of War</h1>Search here for loot left behind after a battle or skirmish'));
+		spoils: [{
+			coords: [[-12.726, -128.452]],
+			label: 'Spoils of War',
+			popup: 'Search here for loot left behind after a battle or skirmish'
+		}]
+	});
 
 	window.allLayers = [
 		markers.abandoned,

--- a/files/js/mapdata-white_orchard.js
+++ b/files/js/mapdata-white_orchard.js
@@ -128,7 +128,7 @@
 
 	// Notice Board
 	markers.notice = L.layerGroup(genericMarkers([
-			[-67.643, -89.385],
+		[-67.643, -89.385],
 	], icons.notice, 'Notice Board', '<h1>Notice Board</h1>Here you can find monster contracts and announcements about matters of local concern'));
 
 	// Person in Distress
@@ -212,17 +212,4 @@
 		markers.smugglers,
 		markers.spoils
 	];
-
-	function genericMarkers(cords, icon, label, popup) {
-		var out = [];
-		$.each(cords, function(key, val)
-		{
-			out.push(L.marker(val, setMarker(icon)).bindLabel(label).bindPopup(popup));
-		});
-		return out;
-	}
-
-	function setMarker(icon, tooltip) {
-		return {icon : icon, riseOnHover : true};
-	}
 }());

--- a/files/js/shared.js
+++ b/files/js/shared.js
@@ -1,0 +1,152 @@
+(function () {
+	window.createMarker = function (coord, icon, label, popup) {
+		return L.marker(coord, setMarker(icon)).bindLabel(label).bindPopup(popup);
+	};
+
+	window.genericMarkers = function (coords, icon, label, popup) {
+		return coords.map(function (coord) {
+			return window.createMarker(coord, icon, label, popup);
+		});
+	}
+
+	window.setMarker = function (icon, tooltip) {
+		return {icon : icon, riseOnHover : true};
+	}
+
+
+	window.icons = {};
+	window.markers = {};
+
+
+	var icons = window.icons;
+
+	icons.abandoned = L.icon({
+		iconUrl  : '/files/img/icons/abandoned.png',
+		iconSize : [30, 30]
+	});
+
+	icons.alchemy = L.icon({
+		iconUrl  : '/files/img/icons/alchemy.png',
+		iconSize : [20, 28]
+	});
+
+	icons.armourer = L.icon({
+		iconUrl  : '/files/img/icons/armourer.png',
+		iconSize : [24, 34]
+	});
+
+	icons.armourerstable = L.icon({
+		iconUrl  : '/files/img/icons/armourerstable.png',
+		iconSize : [30, 27]
+	});
+
+	icons.banditcamp = L.icon({
+		iconUrl  : '/files/img/icons/banditcamp.png',
+		iconSize : [29, 30]
+	});
+
+	icons.barber = L.icon({
+		iconUrl  : '/files/img/icons/barber.png',
+		iconSize : [30, 30]
+	});
+
+	icons.blacksmith = L.icon({
+		iconUrl  : '/files/img/icons/blacksmith.png',
+		iconSize : [27, 30]
+	});
+
+	icons.brothel = L.icon({
+		iconUrl  : '/files/img/icons/brothel.png',
+		iconSize : [28, 26]
+	});
+
+	icons.entrance = L.icon({
+		iconUrl  : '/files/img/icons/entrance.png',
+		iconSize : [28, 27]
+	});
+
+	icons.grindstone = L.icon({
+		iconUrl  : '/files/img/icons/grindstone.png',
+		iconSize : [30, 26]
+	});
+
+	icons.guarded = L.icon({
+		iconUrl  : '/files/img/icons/guarded.png',
+		iconSize : [23, 34]
+	});
+
+	icons.gwent = L.icon({
+		iconUrl  : '/files/img/icons/gwent.png',
+		iconSize : [24, 30]
+	});
+
+	icons.harbor = L.icon({
+		iconUrl  : '/files/img/icons/harbor.png',
+		iconSize : [27, 30]
+	});
+
+	icons.herbalist = L.icon({
+		iconUrl  : '/files/img/icons/herbalist.png',
+		iconSize : [25, 28]
+	});
+
+	icons.hidden = L.icon({
+		iconUrl  : '/files/img/icons/hidden.png',
+		iconSize : [23, 34]
+	});
+
+	icons.innkeep = L.icon({
+		iconUrl  : '/files/img/icons/tavern.png',
+		iconSize : [26, 30]
+	});
+
+	icons.monsterden = L.icon({
+		iconUrl  : '/files/img/icons/monsterden.png',
+		iconSize : [30, 27]
+	});
+
+	icons.monsternest = L.icon({
+		iconUrl  : '/files/img/icons/monsternest.png',
+		iconSize : [23, 30]
+	});
+
+	icons.notice = L.icon({
+		iconUrl  : '/files/img/icons/notice.png',
+		iconSize : [23, 28]
+	});
+
+	icons.pid = L.icon({
+		iconUrl  : '/files/img/icons/pid.png',
+		iconSize : [24, 34]
+	});
+
+	icons.pop = L.icon({
+		iconUrl  : '/files/img/icons/pop.png',
+		iconSize : [27, 30]
+	});
+
+	icons.poi = L.icon({
+		iconUrl  : '/files/img/icons/poi.png',
+		iconSize : [28, 28]
+	});
+
+	icons.shopkeeper = L.icon({
+		iconUrl  : '/files/img/icons/merchant.png',
+		iconSize : [21, 30]
+	});
+
+	icons.signpost = L.icon({
+		iconUrl  : '/files/img/icons/fasttravel.png',
+		iconSize : [27, 34]
+	});
+
+	icons.smugglers = L.icon({
+		iconUrl  : '/files/img/icons/smugglers.png',
+		iconSize : [28, 30]
+	});
+
+	icons.spoils = L.icon({
+		iconUrl  : '/files/img/icons/spoils.png',
+		iconSize : [25, 28]
+	});
+}());

--- a/files/js/shared.js
+++ b/files/js/shared.js
@@ -7,18 +7,33 @@
 		return coords.map(function (coord) {
 			return window.createMarker(coord, icon, label, popup);
 		});
-	}
+	};
 
 	window.setMarker = function (icon, tooltip) {
 		return {icon : icon, riseOnHover : true};
-	}
-
+	};
 
 	window.icons = {};
 	window.markers = {};
 
-
 	var icons = window.icons;
+	var markers = window.markers;
+
+	window.processData = function (data) {
+		Object.keys(data).forEach(function (key) {
+			var items = data[key];
+			var groupItems = [];
+			items.forEach(function (item) {
+				if (item.popupTitle == null) {
+					item.popupTitle = item.label;
+				}
+				item.coords.forEach(function (coord) {
+					groupItems.push(createMarker(coord, icons[key], item.label, '<h1>' + item.popupTitle + '</h1>' + item.popup));
+				});
+			});
+			markers[key] = L.layerGroup(groupItems);
+		});
+	};
 
 	icons.abandoned = L.icon({
 		iconUrl  : '/files/img/icons/abandoned.png',

--- a/s/index.html
+++ b/s/index.html
@@ -18,7 +18,7 @@
 	<body>
 		<div id="sidebar">
 			<div id="sidebar-wrap">
-				<div id="logo"></div>
+				<a href="/"><div id="logo"></div></a>
 				<ul class="key">
 					<li><i class="alchemy"></i><span>Alchemy Supplies</span></li>
 					<li><i class="abandoned"></i><span>Abandoned Site</span></li>

--- a/s/index.html
+++ b/s/index.html
@@ -69,6 +69,7 @@
 		<script type="text/javascript" src="/files/js/jquery.nicescroll.min.js"></script>
 		<script type="text/javascript" src="/files/js/leaflet/leaflet.js"></script>
 		<script type="text/javascript" src="/files/js/leaflet.plugins.js"></script>
+		<script type="text/javascript" src="/files/js/shared.js"></script>
 		<script type="text/javascript" src="/files/js/mapdata-skellige.js"></script>
 		<script type="text/javascript" src="/files/js/custom.js"></script>
 	</body>

--- a/v/index.html
+++ b/v/index.html
@@ -18,7 +18,7 @@
 	<body>
 		<div id="sidebar">
 			<div id="sidebar-wrap">
-				<div id="logo"></div>
+				<a href="/"><div id="logo"></div></a>
 				<ul class="key">
 					<li><i class="alchemy"></i><span>Alchemy Supplies</span></li>
 					<li><i class="abandoned"></i><span>Abandoned Site</span></li>

--- a/v/index.html
+++ b/v/index.html
@@ -72,6 +72,7 @@
 		<script type="text/javascript" src="/files/js/jquery.nicescroll.min.js"></script>
 		<script type="text/javascript" src="/files/js/leaflet/leaflet.js"></script>
 		<script type="text/javascript" src="/files/js/leaflet.plugins.js"></script>
+		<script type="text/javascript" src="/files/js/shared.js"></script>
 		<script type="text/javascript" src="/files/js/mapdata-velen.js"></script>
 		<script type="text/javascript" src="/files/js/custom.js"></script>
 	</body>

--- a/w/index.html
+++ b/w/index.html
@@ -63,6 +63,7 @@
 		<script type="text/javascript" src="/files/js/jquery.nicescroll.min.js"></script>
 		<script type="text/javascript" src="/files/js/leaflet/leaflet.js"></script>
 		<script type="text/javascript" src="/files/js/leaflet.plugins.js"></script>
+		<script type="text/javascript" src="/files/js/shared.js"></script>
 		<script type="text/javascript" src="/files/js/mapdata-white_orchard.js"></script>
 		<script type="text/javascript" src="/files/js/custom.js"></script>
 	</body>

--- a/w/index.html
+++ b/w/index.html
@@ -18,7 +18,7 @@
 	<body>
 		<div id="sidebar">
 			<div id="sidebar-wrap">
-				<div id="logo"></div>
+				<a href="/"><div id="logo"></div></a>
 				<ul class="key">
 					<li><i class="abandoned"></i><span>Abandoned Site</span></li>
 					<li><i class="armourer"></i><span>Armorer</span></li>


### PR DESCRIPTION
There didn't seem to be an easy way to return to the map selection page, so I surrounded the logo with a link back to the homepage.

I also made the scoping of the variables defined in the mapdata scripts more explicit, and eliminated the use of eval from custom.js.