### PR TITLE
Fixed Wild Shore trademark symbol

### DIFF
--- a/files/js/mapdata-skellige.js
+++ b/files/js/mapdata-skellige.js
@@ -943,7 +943,7 @@
 		}, {
 			coords: [[-54.098, -60.754]],
 			label: 'Wild Shore',
-			popup: 'A wild and untamed™ part of the isle\'s coastline. A favourite spot for bandits and lovers'
+			popup: 'A wild and untamed&trade; part of the isle\'s coastline. A favourite spot for bandits and lovers'
 		}, {
 			coords: [[-50.958, -42.935]],
 			label: 'Fornhala',


### PR DESCRIPTION
Added an escape sequence to the Wild Shore's (in Skellige) trademark
symbol so that it now renders properly.