### PR TITLE
Global Search on Map Selection

### DIFF
--- a/files/css/home.css
+++ b/files/css/home.css
@@ -135,6 +135,10 @@ div#search-input-wrapper .fa-times {
 	padding-right: 5px;
 	cursor: pointer;
 }
+div#search-input-container {
+	width:100%;
+	height:26px;
+}
 div#search-input-wrapper > input {
 	width:244px;
 	padding-left:10px;

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -106,12 +106,13 @@ div#search-wrapper {
 	width:100%;
 	font-family: 'PFDinTextCondPro', Arial, sans-serif;
 	font-size:20px;
+	margin-top:30px;
 }
 div#search-input-wrapper {
 	width:300px;
 	margin:auto;
-	color: #bbb;
-	border-color: #bbb;
+	color: #635540;
+	border-color: #635540;
 	-webkit-border-radius: 10px;
 	-moz-border-radius: 10px;
 	border-radius: 10px;

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -126,11 +126,16 @@ div#search-input-wrapper > input {
 	font-family: 'PFDinTextCondPro', Arial, sans-serif;
 	font-size:20px;
 }
+div#search-results-wrapper {
+	width:90%;
+	margin:auto;
+}
 ul#results {
-	margin-left:10%;
-	margin-right:10%;
+	width:100%;
+	margin-top:10px;
 	color: #F0CB0B;
 	list-style-type: none;
+	text-align: left;
 }
 ul#results > li {
 	margin-bottom:10px;
@@ -139,7 +144,6 @@ ul#results > li > a {
 	text-transform: uppercase;
 	margin: -0.35em 0 0.25em;
 	font-size: 20px;
-	text-align: center;
 	color: #635540;
 }
 div#footer, div#push {

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -105,9 +105,10 @@ ul#nav li {
 }
 div#search-wrapper {
 	width:100%;
+	max-width: 1024px;
 	font-family: 'PFDinTextCondPro', Arial, sans-serif;
 	font-size:20px;
-	margin-top:30px;
+	margin:30px auto 0px auto;
 }
 div#search-input-wrapper {
 	width:300px;

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -110,6 +110,11 @@ div#search-wrapper {
 	font-size:20px;
 	margin:30px auto 0px auto;
 }
+div#search-input-container {
+	width:100%;
+	max-width: 1024px;
+	margin:0px auto 0px auto;
+}
 div#search-input-wrapper {
 	width:300px;
 	margin:auto;
@@ -120,6 +125,10 @@ div#search-input-wrapper {
 	border-radius: 10px;
 	border-style: solid;
 	border-width: 1px;
+}
+div.sticky {
+	position:fixed;
+	top:0px;
 }
 div#search-input-wrapper .fa-search {
 	padding-left: 5px;
@@ -150,12 +159,11 @@ div#search-input-wrapper > input:-ms-input-placeholder {
 	color: #635540;
 }
 div#search-results-wrapper {
-	width:90%;
-	margin:auto;
+	width:100%;
+	padding-top:10px;
 }
 ul#results {
 	width:100%;
-	margin-top:10px;
 	list-style-type: none;
 	text-align: left;
 }

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -111,18 +111,19 @@ div#search-input-wrapper {
 	width:300px;
 	margin:auto;
 	color: #bbb;
+	border-color: #bbb;
+	-webkit-border-radius: 10px;
+	-moz-border-radius: 10px;
+	border-radius: 10px;
+	border-style: solid;
+	border-width: 1px;
+	padding-left:5px;
 }
 div#search-input-wrapper > input {
 	width:258px;
-	background: #000;
-	border-color: #bbb;
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  border-radius: 10px;
-	border-style: solid;
-	border-width: 3px;
+	border: none;
+	background: none;
 	color: #F0CB0B;
-	padding-left:10px;
 	font-family: 'PFDinTextCondPro', Arial, sans-serif;
 	font-size:20px;
 }

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -67,6 +67,10 @@ div#logo {
 	width: 300px;
 	height: 155px;
 }
+div#lang {
+	margin-top: 20px;
+	text-align: center;
+}
 ul#nav {
 	text-align: center;
 }

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -117,10 +117,17 @@ div#search-input-wrapper {
 	border-radius: 10px;
 	border-style: solid;
 	border-width: 1px;
-	padding-left:5px;
+}
+div#search-input-wrapper .fa-search {
+	padding-left: 5px;
+}
+div#search-input-wrapper .fa-times {
+	padding-right: 5px;
+	cursor: pointer;
 }
 div#search-input-wrapper > input {
-	width:258px;
+	width:244px;
+	padding-left:10px;
 	border: none;
 	background: none;
 	color: #F0CB0B;
@@ -139,6 +146,7 @@ ul#results {
 	text-align: left;
 }
 ul#results > li {
+	width:100%;
 	margin-bottom:10px;
 }
 ul#results > li > a {

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -58,7 +58,7 @@ div#text {
 	text-align: center;
 	font-size: 20px;
 	margin: 25px 0 20px 0;
-    text-shadow: 1px 1px #000;
+  text-shadow: 1px 1px #000;
 	cursor: default;
 }
 div#logo {
@@ -97,6 +97,46 @@ ul#nav li {
 #nav li.disabled {
 	opacity: 0.5;
 	cursor: not-allowed;
+}
+div#search-wrapper {
+	width:100%;
+	font-family: 'PFDinTextCondPro', Arial, sans-serif;
+	font-size:20px;
+}
+div#search-input-wrapper {
+	width:300px;
+	margin:auto;
+	color: #bbb;
+}
+div#search-input-wrapper > input {
+	width:258px;
+	background: #000;
+	border-color: #bbb;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  border-radius: 10px;
+	border-style: solid;
+	border-width: 3px;
+	color: #F0CB0B;
+	padding-left:10px;
+	font-family: 'PFDinTextCondPro', Arial, sans-serif;
+	font-size:20px;
+}
+ul#results {
+	margin-left:10%;
+	margin-right:10%;
+	color: #F0CB0B;
+	list-style-type: none;
+}
+ul#results > li {
+	margin-bottom:10px;
+}
+ul#results > li > a {
+	text-transform: uppercase;
+	margin: -0.35em 0 0.25em;
+	font-size: 20px;
+	text-align: center;
+	color: #635540;
 }
 div#footer, div#push {
 	height: 40px;

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -141,19 +141,20 @@ div#search-results-wrapper {
 ul#results {
 	width:100%;
 	margin-top:10px;
-	color: #F0CB0B;
 	list-style-type: none;
 	text-align: left;
 }
 ul#results > li {
 	width:100%;
 	margin-bottom:10px;
+	color: #635540;
 }
 ul#results > li > a {
 	text-transform: uppercase;
 	margin: -0.35em 0 0.25em;
 	font-size: 20px;
-	color: #635540;
+	color: #F0CB0B;
+	text-decoration: none;
 }
 div#footer, div#push {
 	height: 40px;

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -176,6 +176,12 @@ div#footer > span > a:active {
 	color: #bbb;
 	text-decoration: none;
 }
+div#lang > a {
+	opacity:0.5;
+}
+div#lang > a:hover {
+	opacity:1;
+}
 div#footer > a:hover {
 	color: #ddd;
 	text-decoration: underline;

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -110,11 +110,6 @@ div#search-wrapper {
 	font-size:20px;
 	margin:30px auto 0px auto;
 }
-div#search-input-container {
-	width:100%;
-	max-width: 1024px;
-	margin:0px auto 0px auto;
-}
 div#search-input-wrapper {
 	width:300px;
 	margin:auto;
@@ -129,6 +124,9 @@ div#search-input-wrapper {
 div.sticky {
 	position:fixed;
 	top:0px;
+	left:50%;
+	margin-left:-151px !important;
+	background: rgba(0, 0, 0, 0.7);
 }
 div#search-input-wrapper .fa-search {
 	padding-left: 5px;
@@ -172,12 +170,19 @@ ul#results > li {
 	margin-bottom:10px;
 	color: #635540;
 }
-ul#results > li > a {
+ul#results > li > div > a {
 	text-transform: uppercase;
 	margin: -0.35em 0 0.25em;
 	font-size: 20px;
 	color: #F0CB0B;
 	text-decoration: none;
+}
+div.searchDescription {
+	width:100%;
+}
+div.truncated {
+	height:24px;
+	overflow: hidden;
 }
 div#footer, div#push {
 	height: 40px;

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -136,6 +136,18 @@ div#search-input-wrapper > input {
 	font-family: 'PFDinTextCondPro', Arial, sans-serif;
 	font-size:20px;
 }
+div#search-input-wrapper > input::-webkit-input-placeholder {
+	color: #635540;
+}
+div#search-input-wrapper > input:-moz-placeholder {
+	color: #635540;
+}
+div#search-input-wrapper > input::-moz-placeholder {
+	color: #635540;
+}
+div#search-input-wrapper > input:-ms-input-placeholder {
+	color: #635540;
+}
 div#search-results-wrapper {
 	width:90%;
 	margin:auto;

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -183,10 +183,13 @@ ul#results > li > div > a {
 }
 div.searchDescription {
 	width:100%;
+	display: table;
+	table-layout: fixed;
 }
 div.truncated {
-	height:24px;
+	white-space: nowrap;
 	overflow: hidden;
+	text-overflow: ellipsis;
 }
 div#footer, div#push {
 	height: 40px;

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -170,9 +170,9 @@ div#footer {
 	max-width: 765px;
 	margin: 0 auto;
 }
-div#footer > a,
-div#footer > a:visited,
-div#footer > a:active {
+div#footer > span > a,
+div#footer > span > a:visited,
+div#footer > span > a:active {
 	color: #bbb;
 	text-decoration: none;
 }

--- a/files/css/home.css
+++ b/files/css/home.css
@@ -44,6 +44,7 @@ div#wrap {
 	height: 100%;
 	margin: 0 auto -40px;
 	display: table;
+	width: 100%;
 }
 div#wrap2 {
 	display: table-cell;

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -40,6 +40,12 @@ $.i18n.init(options, function() {
 
 							//auto search when coming from back button
 							if($('#search').val()) doSearch();
+
+							$('#clear').click(function () {
+								$('#search').val('');
+								$('#results').empty();
+								$('#clear').hide();
+							});
 						});
 					});
 				});
@@ -76,8 +82,10 @@ var doSearch = function() {
 	var searchInput = $('#search').val();
 	if(searchInput.length == 0) {
 			$('#results').empty();
+			$('#clear').hide();
 			return;
 	}
+	$('#clear').show();
 	var regex = new RegExp('(?=[^\\s])' + searchInput, 'gi');
 	var results = [];
 	$.each(mapdata, function(k,v) {

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -21,6 +21,7 @@ var options = {
 
 //i18n init to translate search results
 $.i18n.init(options, function() {
+	$(document).i18n();
 	$.i18n.loadNamespace('v', function() {
 		$.getScript("files/js/mapdata-velen.js").done(function(script, textStatus) {
 			$(document).trigger('loadMapdata');
@@ -46,6 +47,7 @@ $.i18n.init(options, function() {
 								$('#results').empty();
 								$('#clear').hide();
 							});
+
 						});
 					});
 				});
@@ -62,7 +64,7 @@ var processData = function(data) {
 		$.each(markers, function(index,marker) {
 			var link = window.location.href.replace(window.location.hash, '')+mapKey+'/#3/'+marker.coords[0][0]+'/'+marker.coords[0][1]+'/m='+marker.coords[0][0]+','+marker.coords[0][1];
 			mapdata.push({
-				'map':window.map_path.replace('_', ' '),
+				'map': $.t('maps.'+window.map_path),
 				'label':marker.label,
 				'popup':marker.popup,
 				'popupTitle':(marker.popupTitle ? marker.popupTitle : '' ),
@@ -97,7 +99,7 @@ var doSearch = function() {
 		}
 	});
 	$('#results').empty();
-	var count = '<li>'+results.length+' result(s) found.</li>';
+	var count = '<li>'+results.length+' '+$.t('home.resultsFound')+'</li>';
 	$('#results').append($(count));
 	$.each(results, function(k,v) {
 		var label;

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -1,0 +1,85 @@
+var options = {
+	debug: false,
+	getAsync: true,
+	ns: 'general',
+	lng: localStorage['lang'],
+	fallbackLng: 'en',
+	resGetPath: 'files/locales/__lng__/__ns__.json',
+	useDataAttrOptions: true,
+	lngWhitelist: [ 'de', 'en', 'ru' ]
+};
+//i18n init to translate search results
+$.i18n.init(options, function() {
+	$.i18n.loadNamespace('v', function() {
+		$.getScript("files/js/mapdata-velen.js").done(function(script, textStatus) {
+			$(document).trigger('loadMapdata');
+			$(document).unbind('loadMapdata');
+			$.i18n.loadNamespace('s', function() {
+				$.getScript("files/js/mapdata-skellige.js").done(function(script, textStatus) {
+					$(document).trigger('loadMapdata');
+					$(document).unbind('loadMapdata');
+					$.i18n.loadNamespace('w', function() {
+						$.getScript("files/js/mapdata-white_orchard.js").done(function(script, textStatus) {
+							$(document).trigger('loadMapdata');
+							$(document).unbind('loadMapdata');
+							//bind the search when all scripts are loaded
+							$('#search').keyup(function() {
+								doSearch();
+							});
+						});
+					});
+				});
+			});
+		});
+	});
+});
+var mapdata = [];
+var processData = function(data) {
+	var mapKey = map_path.charAt(0);
+	$.each(data, function(markerType,markers) {
+		$.each(markers, function(index,marker) {
+			var link = window.location.href.replace(window.location.hash, '')+mapKey+'/#3/'+marker.coords[0][0]+'/'+marker.coords[0][1]+'/m='+marker.coords[0][0]+','+marker.coords[0][1];
+			mapdata.push({
+				'label':marker.label,
+				'popup':marker.popup,
+				'popupTitle':(marker.popupTitle ? marker.popupTitle : '' ),
+				'link':link
+			});
+		});
+	});
+};
+//mocks to avoid errors on mapdata files
+var L = {};
+L.latLng = function() {};
+window.markers = {};
+
+var doSearch = function() {
+	var searchInput = $('#search').val();
+	if(searchInput.length == 0) {
+			$('#results').empty();
+			return;
+	}
+	var regex = new RegExp('(?=[^\\s])' + searchInput, 'gi');
+	var results = [];
+	$.each(mapdata, function(k,v) {
+		if((v.label.search(regex) != -1) ||
+		(v.popup.search(regex) != -1) ||
+		(v.popupTitle.search(regex) != -1))
+		{
+			results.push(v);
+		}
+	});
+	$('#results').empty();
+	$.each(results, function(k,v) {
+		var label;
+		if(v.popupTitle === '') {
+			label = v.label;
+		} else if(v.popupTitle.indexOf(v.label) > -1) {
+			label = v.popupTitle;
+		} else {
+			label = v.label+' ('+v.popupTitle+')';
+		}
+		var item = '<li><a href="'+v.link+'">'+label+'</a><br/><span>'+v.popup+'</span></li>';
+		$('#results').append($(item));
+	});
+};

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -37,6 +37,9 @@ $.i18n.init(options, function() {
 							$('#search').keyup(function() {
 								doSearch();
 							});
+
+							//auto search when coming from back button
+							if($('#search').val()) doSearch();
 						});
 					});
 				});
@@ -53,6 +56,7 @@ var processData = function(data) {
 		$.each(markers, function(index,marker) {
 			var link = window.location.href.replace(window.location.hash, '')+mapKey+'/#3/'+marker.coords[0][0]+'/'+marker.coords[0][1]+'/m='+marker.coords[0][0]+','+marker.coords[0][1];
 			mapdata.push({
+				'map':window.map_path,
 				'label':marker.label,
 				'popup':marker.popup,
 				'popupTitle':(marker.popupTitle ? marker.popupTitle : '' ),
@@ -85,6 +89,8 @@ var doSearch = function() {
 		}
 	});
 	$('#results').empty();
+	var count = '<li>'+results.length+' result(s) found.</li>';
+	$('#results').append($(count));
 	$.each(results, function(k,v) {
 		var label;
 		if(v.popupTitle === '') {
@@ -94,7 +100,7 @@ var doSearch = function() {
 		} else {
 			label = v.label+' ('+v.popupTitle+')';
 		}
-		var item = '<li><a href="'+v.link+'">'+label+'</a><br/><span>'+v.popup+'</span></li>';
+		var item = '<li><a href="'+v.link+'">'+label+' - '+v.map+'</a><br/><span>'+v.popup+'</span></li>';
 		$('#results').append($(item));
 	});
 };

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -96,7 +96,6 @@ var processData = function(data) {
 			}
 
 			mapdata.push({
-				'allText': marker.label+popupText+popupTitle,
 				'map': $.t('maps.'+window.map_path),
 				'label':label,
 				'popup':popupText,
@@ -129,7 +128,7 @@ var doSearch = function() {
 	var results = [];
 	var mapdataLength = mapdata.length;
 	for(var i=0;i<mapdataLength;i++) {
-		if(mapdata[i].allText.search(regex) != -1) {
+		if((mapdata[i].label.search(regex) != -1) || (mapdata[i].popup.search(regex) != -1)) {
 			results.push(mapdata[i]);
 		}
 	}
@@ -138,17 +137,13 @@ var doSearch = function() {
 	resultsElement.append($(count));
 	var resultsLength = results.length;
 	for(var i=0;i<resultsLength;i++) {
-		var item = '<li><div><a href="'+results[i].link+'">'+results[i].label+' - '+results[i].map+'</a></div><div class="searchDescription truncated">'+results[i].popup+'</div></li>';
+		var item = '<li><div><a href="'+results[i].link+'">'+results[i].label+' - '+results[i].map+'</a></div><div class="searchDescription"><div class="truncated" onclick="toggleTruncate(event, this)">'+results[i].popup+'</div></div></li>';
 		resultsElement.append($(item));
 	}
-	var expand = '<span style="float:right;">&#x25BC;</span>';
-	$('#results').find('div.searchDescription').each(function() {
-		if($(this)[0].scrollHeight > 24) {
-			$(this).prepend($(expand));
-		}
-	});
-	$('#results').on('click','div.searchDescription',function(e) {
-		$(this).children().first().remove();
-		$(this).removeClass("truncated");
-	});
+};
+
+var toggleTruncate = function(e, element) {
+	e.preventDefault();
+	e.stopPropagation();
+	$(element).toggleClass("truncated");
 };

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -127,11 +127,12 @@ var doSearch = function() {
 	}
 	var regex = new RegExp('(?=[^\\s])' + searchText, 'gi');
 	var results = [];
-	$.each(mapdata, function(k,v) {
-		if(v.allText.search(regex) != -1) {
-			results.push(v);
+	var mapdataLength = mapdata.length;
+	for(var i=0;i<mapdataLength;i++) {
+		if(mapdata[i].allText.search(regex) != -1) {
+			results.push(mapdata[i]);
 		}
-	});
+	}
 	resultsElement.empty();
 	var count = '<li>'+results.length+' '+$.t('home.resultsFound')+'</li>';
 	resultsElement.append($(count));
@@ -141,13 +142,13 @@ var doSearch = function() {
 		resultsElement.append($(item));
 	}
 	var expand = '<span style="float:right;">&#x25BC;</span>';
-	$('#results > li > .searchDescription').each(function() {
+	$('#results').find('div.searchDescription').each(function() {
 		if($(this)[0].scrollHeight > 24) {
 			$(this).prepend($(expand));
-			$(this).on("click", function(e) {
-				$(this).children().first().remove();
-				$(this).removeClass("truncated");
-			});
 		}
+	});
+	$('#results').on('click','div.searchDescription',function(e) {
+		$(this).children().first().remove();
+		$(this).removeClass("truncated");
 	});
 };

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -34,20 +34,22 @@ $.i18n.init(options, function() {
 						$.getScript("files/js/mapdata-white_orchard.js").done(function(script, textStatus) {
 							$(document).trigger('loadMapdata');
 							$(document).unbind('loadMapdata');
+
+							var searchInput = $('#search');
+
 							//bind the search when all scripts are loaded
-							$('#search').keyup(function() {
+							searchInput.keyup(function() {
 								doSearch();
 							});
 
 							//auto search when coming from back button
-							if($('#search').val()) doSearch();
+							if(searchInput.val()) doSearch();
 
 							$('#clear').click(function () {
 								$('#search').val('');
 								$('#results').empty();
 								$('#clear').hide();
 							});
-
 						});
 					});
 				});
@@ -55,6 +57,23 @@ $.i18n.init(options, function() {
 		});
 	});
 });
+
+
+$(function() {
+	var s = $('#search-input-container');
+	var pos = s.position();
+	//setup sticky searchbar
+	$(window).scroll(function() {
+		var windowpos = $(window).scrollTop();
+		console.log(pos.top + ' ' + windowpos);
+		if (windowpos >= pos.top) {
+			s.addClass("sticky");
+		} else {
+			s.removeClass("sticky");
+		}
+	});
+});
+
 
 //mocks shared.js processData function to generate search results
 var mapdata = [];
@@ -81,14 +100,14 @@ window.markers = {};
 
 //search function
 var doSearch = function() {
-	var searchInput = $('#search').val();
-	if(searchInput.length == 0) {
+	var searchText = $('#search').val();
+	if(searchText.length === 0) {
 			$('#results').empty();
 			$('#clear').hide();
 			return;
 	}
 	$('#clear').show();
-	var regex = new RegExp('(?=[^\\s])' + searchInput, 'gi');
+	var regex = new RegExp('(?=[^\\s])' + searchText, 'gi');
 	var results = [];
 	$.each(mapdata, function(k,v) {
 		if((v.label.search(regex) != -1) ||

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -66,7 +66,7 @@ var processData = function(data) {
 			mapdata.push({
 				'map': $.t('maps.'+window.map_path),
 				'label':marker.label,
-				'popup':marker.popup,
+				'popup':marker.popup.replace(/<a\b[^>]*>/i,"").replace(/<\/a>/i, ""),
 				'popupTitle':(marker.popupTitle ? marker.popupTitle : '' ),
 				'link':link
 			});

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -62,7 +62,7 @@ var processData = function(data) {
 		$.each(markers, function(index,marker) {
 			var link = window.location.href.replace(window.location.hash, '')+mapKey+'/#3/'+marker.coords[0][0]+'/'+marker.coords[0][1]+'/m='+marker.coords[0][0]+','+marker.coords[0][1];
 			mapdata.push({
-				'map':window.map_path,
+				'map':window.map_path.replace('_', ' '),
 				'label':marker.label,
 				'popup':marker.popup,
 				'popupTitle':(marker.popupTitle ? marker.popupTitle : '' ),

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -1,3 +1,13 @@
+if (localStorage['lang'] == null) {
+	var lang = window.navigator.userLanguage || window.navigator.language;
+	lang = lang.substring(0,2);
+	localStorage['lang'] = lang;
+}
+
+window.changeLang = function(lang) {
+	localStorage['lang'] = lang;
+};
+
 var options = {
 	debug: false,
 	getAsync: true,
@@ -8,6 +18,7 @@ var options = {
 	useDataAttrOptions: true,
 	lngWhitelist: [ 'de', 'en', 'ru' ]
 };
+
 //i18n init to translate search results
 $.i18n.init(options, function() {
 	$.i18n.loadNamespace('v', function() {
@@ -33,6 +44,8 @@ $.i18n.init(options, function() {
 		});
 	});
 });
+
+//mocks shared.js processData function to generate search results
 var mapdata = [];
 var processData = function(data) {
 	var mapKey = map_path.charAt(0);
@@ -48,11 +61,13 @@ var processData = function(data) {
 		});
 	});
 };
-//mocks to avoid errors on mapdata files
+
+//empty mocks to avoid errors on mapdata files
 var L = {};
 L.latLng = function() {};
 window.markers = {};
 
+//search function
 var doSearch = function() {
 	var searchInput = $('#search').val();
 	if(searchInput.length == 0) {

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -84,11 +84,22 @@ var processData = function(data) {
 	$.each(data, function(markerType,markers) {
 		$.each(markers, function(index,marker) {
 			var link = window.location.href.replace(window.location.hash, '')+mapKey+'/#3/'+marker.coords[0][0]+'/'+marker.coords[0][1]+'/m='+marker.coords[0][0]+','+marker.coords[0][1];
+			var popupText = marker.popup.replace(/<a\b[^>]*>/i,"").replace(/<\/a>/i, "");
+			var popupTitle = (marker.popupTitle ? marker.popupTitle : '' );
+			var label;
+			if(popupTitle === '') {
+				label = marker.label;
+			} else if(popupTitle.indexOf(marker.label) > -1) {
+				label = popupTitle;
+			} else {
+				label = marker.label+' ('+popupTitle+')';
+			}
+
 			mapdata.push({
+				'allText': marker.label+popupText+popupTitle,
 				'map': $.t('maps.'+window.map_path),
-				'label':marker.label,
-				'popup':marker.popup.replace(/<a\b[^>]*>/i,"").replace(/<\/a>/i, ""),
-				'popupTitle':(marker.popupTitle ? marker.popupTitle : '' ),
+				'label':label,
+				'popup':popupText,
 				'link':link
 			});
 		});
@@ -111,34 +122,24 @@ var doSearch = function() {
 			$('#nav').show();
 			return;
 	} else {
+		$('#clear').show();
 		$('#nav').hide();
 	}
-	$('#clear').show();
 	var regex = new RegExp('(?=[^\\s])' + searchText, 'gi');
 	var results = [];
 	$.each(mapdata, function(k,v) {
-		if((v.label.search(regex) != -1) ||
-		(v.popup.search(regex) != -1) ||
-		(v.popupTitle.search(regex) != -1))
-		{
+		if(v.allText.search(regex) != -1) {
 			results.push(v);
 		}
 	});
 	resultsElement.empty();
 	var count = '<li>'+results.length+' '+$.t('home.resultsFound')+'</li>';
 	resultsElement.append($(count));
-	$.each(results, function(k,v) {
-		var label;
-		if(v.popupTitle === '') {
-			label = v.label;
-		} else if(v.popupTitle.indexOf(v.label) > -1) {
-			label = v.popupTitle;
-		} else {
-			label = v.label+' ('+v.popupTitle+')';
-		}
-		var item = '<li><div><a href="'+v.link+'">'+label+' - '+v.map+'</a></div><div class="searchDescription truncated">'+v.popup+'</div></li>';
+	var resultsLength = results.length;
+	for(var i=0;i<resultsLength;i++) {
+		var item = '<li><div><a href="'+results[i].link+'">'+results[i].label+' - '+results[i].map+'</a></div><div class="searchDescription truncated">'+results[i].popup+'</div></li>';
 		resultsElement.append($(item));
-	});
+	}
 	var expand = '<span style="float:right;">&#x25BC;</span>';
 	$('#results > li > .searchDescription').each(function() {
 		if($(this)[0].scrollHeight > 24) {

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -49,6 +49,7 @@ $.i18n.init(options, function() {
 								$('#search').val('');
 								$('#results').empty();
 								$('#clear').hide();
+								$('#nav').show();
 							});
 						});
 					});
@@ -101,11 +102,16 @@ window.markers = {};
 
 //search function
 var doSearch = function() {
-	var searchText = $('#search').val();
+	var searchElement = $('#search');
+	var resultsElement = $('#results');
+	var searchText = searchElement.val();
 	if(searchText.length === 0) {
-			$('#results').empty();
+			resultsElement.empty();
 			$('#clear').hide();
+			$('#nav').show();
 			return;
+	} else {
+		$('#nav').hide();
 	}
 	$('#clear').show();
 	var regex = new RegExp('(?=[^\\s])' + searchText, 'gi');
@@ -118,9 +124,9 @@ var doSearch = function() {
 			results.push(v);
 		}
 	});
-	$('#results').empty();
+	resultsElement.empty();
 	var count = '<li>'+results.length+' '+$.t('home.resultsFound')+'</li>';
-	$('#results').append($(count));
+	resultsElement.append($(count));
 	$.each(results, function(k,v) {
 		var label;
 		if(v.popupTitle === '') {
@@ -131,7 +137,7 @@ var doSearch = function() {
 			label = v.label+' ('+v.popupTitle+')';
 		}
 		var item = '<li><div><a href="'+v.link+'">'+label+' - '+v.map+'</a></div><div class="searchDescription truncated">'+v.popup+'</div></li>';
-		$('#results').append($(item));
+		resultsElement.append($(item));
 	});
 	var expand = '<span style="float:right;">&#x25BC;</span>';
 	$('#results > li > .searchDescription').each(function() {

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -66,7 +66,9 @@ $(function() {
 	$(window).scroll(function() {
 		var windowpos = $(window).scrollTop();
 		if (windowpos >= pos.top) {
-			s.addClass("sticky");
+			if($('#search').val()) {
+				s.addClass("sticky");
+			}
 		} else {
 			s.removeClass("sticky");
 		}

--- a/files/js/home.js
+++ b/files/js/home.js
@@ -60,12 +60,11 @@ $.i18n.init(options, function() {
 
 
 $(function() {
-	var s = $('#search-input-container');
+	var s = $('#search-input-wrapper');
 	var pos = s.position();
 	//setup sticky searchbar
 	$(window).scroll(function() {
 		var windowpos = $(window).scrollTop();
-		console.log(pos.top + ' ' + windowpos);
 		if (windowpos >= pos.top) {
 			s.addClass("sticky");
 		} else {
@@ -129,7 +128,17 @@ var doSearch = function() {
 		} else {
 			label = v.label+' ('+v.popupTitle+')';
 		}
-		var item = '<li><a href="'+v.link+'">'+label+' - '+v.map+'</a><br/><span>'+v.popup+'</span></li>';
+		var item = '<li><div><a href="'+v.link+'">'+label+' - '+v.map+'</a></div><div class="searchDescription truncated">'+v.popup+'</div></li>';
 		$('#results').append($(item));
+	});
+	var expand = '<span style="float:right;">&#x25BC;</span>';
+	$('#results > li > .searchDescription').each(function() {
+		if($(this)[0].scrollHeight > 24) {
+			$(this).prepend($(expand));
+			$(this).on("click", function(e) {
+				$(this).children().first().remove();
+				$(this).removeClass("truncated");
+			});
+		}
 	});
 };

--- a/files/locales/en/general.json
+++ b/files/locales/en/general.json
@@ -7,7 +7,8 @@
 	},
 	"home": {
 		"tagline": "Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)",
-		"resultsFound": "result(s) found."
+		"resultsFound": "result(s) found.",
+		"searchPlaceholder": "Enter search terms..."
 	},
 	"sidebar": {
 		"returnToMapSelection": "Return to Map Selection Page",

--- a/files/locales/en/general.json
+++ b/files/locales/en/general.json
@@ -1,11 +1,9 @@
 {
 	"maps": {
-		"velen": "Velen",
-		"novigrad": "Novigrad",
+		"velen": "Velen & Novigrad",
 		"skellige": "Skellige Isles",
 		"white_orchard": "White Orchard",
-		"kaer_morhen": "Kaer Morhen",
-		"velenAndNovigrad": "$t(maps.velen) & $t(maps.novigrad)"
+		"kaer_morhen": "Kaer Morhen"
 	},
 	"home": {
 		"tagline": "Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)",

--- a/files/locales/en/general.json
+++ b/files/locales/en/general.json
@@ -1,4 +1,16 @@
 {
+	"maps": {
+		"velen": "Velen",
+		"novigrad": "Novigrad",
+		"skellige": "Skellige Isles",
+		"white_orchard": "White Orchard",
+		"kaer_morhen": "Kaer Morhen",
+		"velenAndNovigrad": "$t(maps.velen) & $t(maps.novigrad)"
+	},
+	"home": {
+		"tagline": "Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)",
+		"resultsFound": "result(s) found."
+	},
 	"sidebar": {
 		"returnToMapSelection": "Return to Map Selection Page",
 		"alchemy": "Alchemy Supplies",
@@ -48,6 +60,7 @@
 	},
 	"credits": {
 		"botCreated": "Created by __untamed0__, licensed under __license__",
+		"botHelp": "With help from __mcarver__, & other __contributors__. Thanks to __designGears__ & __hhrhhr__ for map & asset extraction. For the full list of Javascript libraries used, __jsCredits__.",
 		"botAssets": "Witcher 3, logo, icons, map &amp; text are the property of __cdpr__"
 	},
 	"misc": {

--- a/index.html
+++ b/index.html
@@ -28,9 +28,7 @@
 					<div id="logo"></div>
 					<div id="text" data-i18n="[html]home.tagline">Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)</div>
 					<div id="search-wrapper">
-						<div id="search-input-container">
-							<div id="search-input-wrapper"><i class="fa fa-search"></i><input id="search" type="text" data-i18n="[placeholder]home.searchPlaceholder" placeholder="Enter search terms..." autocomplete="off"><i id="clear" class="fa fa-times" style="display:none;"></i></div>
-						</div>
+						<div id="search-input-wrapper"><i class="fa fa-search"></i><input id="search" type="text" data-i18n="[placeholder]home.searchPlaceholder" placeholder="Enter search terms..." autocomplete="off"><i id="clear" class="fa fa-times" style="display:none;"></i></div>
 						<div id="search-results-wrapper"><ul id="results"></ul></div>
 					</div>
 					<ul id="nav">

--- a/index.html
+++ b/index.html
@@ -26,16 +26,16 @@
 			<div id="wrap2">
 				<div id="content">
 					<div id="logo"></div>
-					<div id="text">Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)</div>
+					<div id="text" data-i18n="[html]home.tagline">Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)</div>
 					<div id="search-wrapper">
 						<div id="search-input-wrapper"><i class="fa fa-search"></i><input id="search" type="text"><i id="clear" class="fa fa-times" style="display:none;"></i></div>
 						<div id="search-results-wrapper"><ul id="results"></ul></div>
 					</div>
 					<ul id="nav">
-						<li class="enabled"><a href="w/">White Orchard</a></li>
-						<li class="enabled"><a href="v/">Velen &amp; Novigrad</a></li>
-						<li class="enabled"><a href="s/">Skellige Isles</a></li>
-						<li class="disabled">Kaer Morhen</li>
+						<li class="enabled"><a href="w/" data-i18n="maps.white_orchard">White Orchard</a></li>
+						<li class="enabled"><a href="v/" data-i18n="maps.velenAndNovigrad">Velen &amp; Novigrad</a></li>
+						<li class="enabled"><a href="s/" data-i18n="maps.skellige">Skellige Isles</a></li>
+						<li class="disabled" data-i18n="maps.kaer_morhen">Kaer Morhen</li>
 					</ul>
 					<div id="lang">
 						<a href="" onclick="changeLang('en')" title="English"><img src="files/img/flags/en.png"></a>
@@ -47,7 +47,7 @@
 			<div id="push"></div>
 		</div>
 		<div id="footer">
-			Created by <a href="https://github.com/untamed0" target="_blank">untamed0</a>, licensed under <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">CC BY-NC-SA</a>. With help from <a href="https://github.com/mcarver" target="_blank">mcarver</a> &amp; other <a href="https://github.com/untamed0/witcher3map/graphs/contributors" target="_blank">contributors</a>. Thanks to <a href="https://twitter.com/DesignGears" target="_blank">DesignGears</a> &amp; <a href="https://github.com/hhrhhr" target="_blank">hhrhhr</a> for map &amp; asset extraction. For the full list of Javascript libraries used, <a href="#" class="js-credits">click here</a>. The Witcher 3, logo, icons, map &amp; text are the property of <a href="http://en.cdprojektred.com/" target="_blank">CD PROJEKT RED</a> and used without permission
+			<span data-i18n="[html]credits.botCreated" data-i18n-options='{"untamed0":"<a href=\"https://github.com/untamed0\" target=\"_blank\">untamed0</a>","license":"<a href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\" target=\"_blank\">CC BY-NC-SA</a>"}'>Created by <a href="https://github.com/untamed0" target="_blank">untamed0</a>, licensed under <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">CC BY-NC-SA</a>.</span> <span data-i18n="[html]credits.botHelp" data-i18n-options='{"mcarver":"<a href=\"https://github.com/mcarver\" target=\"_blank\">mcarver</a>","contributors":"<a href=\"https://github.com/untamed0/witcher3map/graphs/contributors\" target=\"_blank\">contributors</a>","designGears":"<a href=\"https://twitter.com/DesignGears\" target=\"_blank\">DesignGears</a>","hhrhhr":"<a href=\"https://github.com/hhrhhr\" target=\"_blank\">hhrhhr</a>","jsCredits":"<a href=\"#\" class=\"js-credits\">click here</a>"}'>With help from <a href="https://github.com/mcarver" target="_blank">mcarver</a> &amp; other <a href="https://github.com/untamed0/witcher3map/graphs/contributors" target="_blank">contributors</a>. Thanks to <a href="https://twitter.com/DesignGears" target="_blank">DesignGears</a> &amp; <a href="https://github.com/hhrhhr" target="_blank">hhrhhr</a> for map &amp; asset extraction. For the full list of Javascript libraries used, <a href="#" class="js-credits">click here</a>.</span> <span data-i18n="[html]credits.botAssets" data-i18n-options='{"cdpr":"<a href=\"http://en.cdprojektred.com\" target=\"_blank\">CD PROJEKT RED</a>"}'>Witcher 3, logo, icons, map &amp; text are the property of <a href="http://en.cdprojektred.com" target="_blank">CD PROJEKT RED</a>'>The Witcher 3, logo, icons, map &amp; text are the property of <a href="http://en.cdprojektred.com/" target="_blank">CD PROJEKT RED</a> and used without permission</span>
 		</div>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 					</div>
 					<ul id="nav">
 						<li class="enabled"><a href="w/" data-i18n="maps.white_orchard">White Orchard</a></li>
-						<li class="enabled"><a href="v/" data-i18n="maps.velenAndNovigrad">Velen &amp; Novigrad</a></li>
+						<li class="enabled"><a href="v/" data-i18n="maps.velen">Velen &amp; Novigrad</a></li>
 						<li class="enabled"><a href="s/" data-i18n="maps.skellige">Skellige Isles</a></li>
 						<li class="disabled" data-i18n="maps.kaer_morhen">Kaer Morhen</li>
 					</ul>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,9 @@
 					<div id="logo"></div>
 					<div id="text" data-i18n="[html]home.tagline">Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)</div>
 					<div id="search-wrapper">
-						<div id="search-input-wrapper"><i class="fa fa-search"></i><input id="search" type="text" data-i18n="[placeholder]home.searchPlaceholder" placeholder="Enter search terms..." autocomplete="off"><i id="clear" class="fa fa-times" style="display:none;"></i></div>
+						<div id="search-input-container">
+							<div id="search-input-wrapper"><i class="fa fa-search"></i><input id="search" type="text" data-i18n="[placeholder]home.searchPlaceholder" placeholder="Enter search terms..." autocomplete="off"><i id="clear" class="fa fa-times" style="display:none;"></i></div>
+						</div>
 						<div id="search-results-wrapper"><ul id="results"></ul></div>
 					</div>
 					<ul id="nav">

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 					<div id="logo"></div>
 					<div id="text" data-i18n="[html]home.tagline">Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)</div>
 					<div id="search-wrapper">
-						<div id="search-input-wrapper"><i class="fa fa-search"></i><input id="search" type="text"><i id="clear" class="fa fa-times" style="display:none;"></i></div>
+						<div id="search-input-wrapper"><i class="fa fa-search"></i><input id="search" type="text" data-i18n="[placeholder]home.searchPlaceholder" placeholder="Enter search terms..." autocomplete="off"><i id="clear" class="fa fa-times" style="display:none;"></i></div>
 						<div id="search-results-wrapper"><ul id="results"></ul></div>
 					</div>
 					<ul id="nav">

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 					<div id="logo"></div>
 					<div id="text">Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)</div>
 					<div id="search-wrapper">
-						<div id="search-input-wrapper"><i class="fa fa-search"></i>&nbsp;<input id="search" type="text"></div>
+						<div id="search-input-wrapper"><i class="fa fa-search"></i><input id="search" type="text"><i id="clear" class="fa fa-times" style="display:none;"></i></div>
 						<div id="search-results-wrapper"><ul id="results"></ul></div>
 					</div>
 					<ul id="nav">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<title>Witcher 3 Interactive Maps</title>
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta charset="utf-8"> 
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width,initial-scale=1.0">
 		<meta property="og:title" content="Witcher 3 Interactive Maps">
 		<meta property="og:type" content="website">
@@ -13,6 +13,10 @@
 		<meta name="description" content="Witcher 3 interactive maps. All locations including shopkeepers, gwent players, merchants, places of power">
 		<meta name="keywords" content="Witcher 3, Witcher 3 map, Witcher 3 interactive map, gwent player map, gwent map, shopkeeper map, merchant map">
 		<link type="text/css" rel="stylesheet" href="files/css/home.css">
+		<link type="text/css" rel="stylesheet" href="files/css/font-awesome.min.css">
+		<script type="text/javascript" src="files/js/jquery-2.1.4.min.js"></script>
+		<script type="text/javascript" src="files/js/i18next-1.9.0.min.js"></script>
+		<script type="text/javascript" src="files/js/home.js"></script>
 		<script type="text/javascript">
 			(function(a,e,f,g,b,c,d){a.GoogleAnalyticsObject=b;a[b]=a[b]||function(){(a[b].q=a[b].q||[]).push(arguments)};a[b].l=1*new Date;c=e.createElement(f);d=e.getElementsByTagName(f)[0];c.async=1;c.src=g;d.parentNode.insertBefore(c,d)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');ga('create','UA-64557825-1','auto');ga('send','pageview');
 		</script>
@@ -23,6 +27,10 @@
 				<div id="content">
 					<div id="logo"></div>
 					<div id="text">Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)</div>
+					<div id="search-wrapper">
+						<div id="search-input-wrapper"><i class="fa fa-search"></i>&nbsp;<input id="search" type="text"></div>
+						<ul id="results"></ul>
+					</div>
 					<ul id="nav">
 						<li class="enabled"><a href="w/">White Orchard</a></li>
 						<li class="enabled"><a href="v/">Velen &amp; Novigrad</a></li>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 					<div id="text">Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)</div>
 					<div id="search-wrapper">
 						<div id="search-input-wrapper"><i class="fa fa-search"></i>&nbsp;<input id="search" type="text"></div>
-						<ul id="results"></ul>
+						<div id="search-results-wrapper"><ul id="results"></ul></div>
 					</div>
 					<ul id="nav">
 						<li class="enabled"><a href="w/">White Orchard</a></li>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 					<div id="logo"></div>
 					<div id="text" data-i18n="[html]home.tagline">Unofficial The Witcher 3 Interactive Maps<br>(Currently under development)</div>
 					<div id="search-wrapper">
-						<div id="search-input-wrapper"><i class="fa fa-search"></i><input id="search" type="text" data-i18n="[placeholder]home.searchPlaceholder" placeholder="Enter search terms..." autocomplete="off"><i id="clear" class="fa fa-times" style="display:none;"></i></div>
+						<div id="search-input-container"><div id="search-input-wrapper"><i class="fa fa-search"></i><input id="search" type="text" data-i18n="[placeholder]home.searchPlaceholder" placeholder="Enter search terms..." autocomplete="off"><i id="clear" class="fa fa-times" style="display:none;"></i></div></div>
 						<div id="search-results-wrapper"><ul id="results"></ul></div>
 					</div>
 					<ul id="nav">

--- a/index.html
+++ b/index.html
@@ -37,6 +37,11 @@
 						<li class="enabled"><a href="s/">Skellige Isles</a></li>
 						<li class="disabled">Kaer Morhen</li>
 					</ul>
+					<div id="lang">
+						<a href="" onclick="changeLang('en')" title="English"><img src="files/img/flags/en.png"></a>
+						<a href="" onclick="changeLang('de')" title="Deutsch"><img src="files/img/flags/de.png"></a>
+						<a href="" onclick="changeLang('ru')" title="Русский"><img src="files/img/flags/ru.png"></a>
+					</div>
 				</div>
 			</div>
 			<div id="push"></div>


### PR DESCRIPTION
Added global search and language switcher to the Map Selection Page.  This will fulfill enhancement request #12.  ~~The only thing outstanding here is i18n for the Map Selection Page text (although the search results use the translated mapdata files).~~

Global real-time/live search features:
* Searches all markers across all 3 maps
* Works with all current (and future) translations, results will show using presently selected language
* Displays the map-name of found result
* Displays the total number of results found
* Results are links to the actual marker, clicking them loads that map with the highlighted marker selected
* Clear button shows/hides depending on if text is entered in the search box, allowing the search results to be closed out quickly
* Back button from map returns to map selection page and the search is automatically performed again (helpful for jumping back and forth)
* Mobile-friendly down to 320x480 (old iPhones/small Androids)

Search Box:
![screenshot 2015-07-03 at 13 08 31](https://cloud.githubusercontent.com/assets/124755/8506079/8b7ef41e-21d0-11e5-97be-5cd9c8bc4b69.png)

Search Results:
![screenshot 2015-07-03 at 13 08 12](https://cloud.githubusercontent.com/assets/124755/8506081/9711db98-21d0-11e5-98ba-145f9df0cd6a.png)

Thoughts?