### PR TITLE
Patch 1.00

### DIFF
--- a/files/js/mapdata-skellige.js
+++ b/files/js/mapdata-skellige.js
@@ -896,6 +896,36 @@ $(document).on("loadMapdata", function () {
 			label: $.t("s:poi.label.mastercraftedFelineSilverSword"),
 			popupTitle:  $.t("s:poi.popupTitle.mastercraftedFelineSilverSword"),
 			popup: $.t("s:poi.desc.mastercraftedFelineSilverSword")
+		}, {
+			coords: [[-37.440, -21.907]],
+			label: $.t("s:poi.label.mastercraftedWolvenGauntlets"),
+			popupTitle:  $.t("s:poi.popupTitle.mastercraftedWolvenGauntlets"),
+			popup: $.t("s:poi.desc.mastercraftedWolvenGauntlets")
+		}, {
+			coords: [[22.634,-120.850]],
+			label: $.t("s:poi.label.mastercraftedWolvenTrousers"),
+			popupTitle:  $.t("s:poi.popupTitle.mastercraftedWolvenTrousers"),
+			popup: $.t("s:poi.desc.mastercraftedWolvenTrousers")
+		}, {
+			coords: [[-58.043, -107.886]],
+			label: $.t("s:poi.label.mastercraftedWolvenBoots"),
+			popupTitle:  $.t("s:poi.popupTitle.mastercraftedWolvenBoots"),
+			popup: $.t("s:poi.desc.mastercraftedWolvenBoots")
+		}, {
+			coords: [[-27.722, 73.894]],
+			label: $.t("s:poi.label.superiorWolvenSteelSword"),
+			popupTitle:  $.t("s:poi.popupTitle.superiorWolvenSteelSword"),
+			popup: $.t("s:poi.desc.superiorWolvenSteelSword")
+		}, {
+			coords: [[-46.119, -57.437]],
+			label: $.t("s:poi.label.superiorWolvenSilverSword"),
+			popupTitle:  $.t("s:poi.popupTitle.superiorWolvenSilverSword"),
+			popup: $.t("s:poi.desc.superiorWolvenSilverSword")
+		}, {
+			coords: [[-59.221, -23.730]],
+			label: $.t("s:poi.label.superiorWolvenArmor"),
+			popupTitle:  $.t("s:poi.popupTitle.superiorWolvenArmor"),
+			popup: $.t("s:poi.desc.superiorWolvenArmor")
 		}],
 
 	// Shopkeeper

--- a/files/js/mapdata-velen.js
+++ b/files/js/mapdata-velen.js
@@ -84,7 +84,7 @@ $(document).on("loadMapdata", function () {
 			coords: [[-30.87, -71.63]],
 			label: $.t("v:armourer.masterLabel"),
 			popupTitle: $.t("v:armourer.yoana"),
-			popup: $.t("v:armourer.quest") + $.t("armourer.desc")
+			popup: $.t("v:armourer.quest") + $.t("v:armourer.desc")
 		}],
 
 	// Armourer's Table

--- a/files/js/mapdata-velen.js
+++ b/files/js/mapdata-velen.js
@@ -1229,8 +1229,7 @@ $(document).on("loadMapdata", function () {
 			label: $.t("poi.label.witcherGear"),
 			popupTitle: $.t("poi.popup.witcherGear.steelsword.wolven.mastercrafted"),
 			popup: $.t("poi.desc.witcherGear.steelsword.wolven.mastercrafted")
-		}
-		],
+		}],
 
 	// Shopkeeper
 		shopkeeper: [{ // Novigrad

--- a/files/js/mapdata-velen.js
+++ b/files/js/mapdata-velen.js
@@ -1199,7 +1199,38 @@ $(document).on("loadMapdata", function () {
 			label: $.t("poi.label.witcherGear"),
 			popupTitle: $.t("poi.popup.witcherGear.gauntlets.ursine.superior"),
 			popup: $.t("poi.desc.witcherGear.gauntlets.ursine.superior")
-		}],
+		}, {
+			coords: [[-28.710, -77.410]],
+			label: $.t("poi.label.witcherGear"),
+			popupTitle: $.t("poi.popup.witcherGear.silversword.wolven.enhanced"),
+			popup: $.t("poi.desc.witcherGear.silversword.wolven.enhanced")
+		}, {
+			coords: [[-23.645, 72.070]],
+			label: $.t("poi.label.witcherGear"),
+			popupTitle: $.t("poi.popup.witcherGear.boots.wolven.enhanced"),
+			popup: $.t("poi.desc.witcherGear.boots.wolven.enhanced")
+		}, {
+			coords: [[-77.128, -78.926]],
+			label: $.t("poi.label.witcherGear"),
+			popupTitle: $.t("poi.popup.witcherGear.armor.wolven.enhanced"),
+			popup: $.t("poi.desc.witcherGear.armor.wolven.enhanced")
+		}, {
+			coords: [[-72.836, 76.816]],
+			label: $.t("poi.label.witcherGear"),
+			popupTitle: $.t("poi.popup.witcherGear.silversword.wolven.mastercrafted"),
+			popup: $.t("poi.desc.witcherGear.silversword.wolven.mastercrafted")
+		}, {
+			coords: [[-77.897, -104.963]],
+			label: $.t("poi.label.witcherGear"),
+			popupTitle: $.t("poi.popup.witcherGear.armor.wolven.mastercrafted"),
+			popup: $.t("poi.desc.witcherGear.armor.wolven.mastercrafted")
+		}, {
+			coords: [[-74.496, -145.239]],
+			label: $.t("poi.label.witcherGear"),
+			popupTitle: $.t("poi.popup.witcherGear.steelsword.wolven.mastercrafted"),
+			popup: $.t("poi.desc.witcherGear.steelsword.wolven.mastercrafted")
+		}
+		],
 
 	// Shopkeeper
 		shopkeeper: [{ // Novigrad

--- a/files/locales/en/general.json
+++ b/files/locales/en/general.json
@@ -140,6 +140,12 @@
 						"enhanced": "",
 						"superior": "",
 						"mastercrafted": ""
+					},
+					"wolven": {
+						"standard": "",
+						"enhanced": "Going down into the cave",
+						"superior": "",
+						"mastercrafted": "You will find near the hidden treasure"
 					}
 				},
 				"steelsword": {
@@ -160,6 +166,12 @@
 						"enhanced": "",
 						"superior": "",
 						"mastercrafted": ""
+					},
+					"wolven": {
+						"standard": "",
+						"enhanced": "",
+						"superior": "",
+						"mastercrafted": "You will find in the hold of the sunken ship"
 					}
 				},
 				"crossbow": {
@@ -184,6 +196,12 @@
 						"enhanced": "",
 						"superior": "",
 						"mastercrafted": ""
+					},
+					"wolven": {
+						"standard": "",
+						"enhanced": "Dive into the water",
+						"superior": "",
+						"mastercrafted": "The chest is inside the well"
 					}
 				},
 				"boots": {
@@ -202,6 +220,12 @@
 					"ursine": {
 						"standard": "",
 						"enhanced": "",
+						"superior": "",
+						"mastercrafted": ""
+					},
+					"wolven": {
+						"standard": "",
+						"enhanced": "Going down into the cave",
 						"superior": "",
 						"mastercrafted": ""
 					}
@@ -224,6 +248,12 @@
 						"enhanced": "",
 						"superior": "",
 						"mastercrafted": ""
+					},
+					"wolven": {
+						"standard": "",
+						"enhanced": "",
+						"superior": "",
+						"mastercrafted": ""
 					}
 				},
 				"trousers": {
@@ -240,6 +270,12 @@
 						"mastercrafted": ""
 					},
 					"ursine": {
+						"standard": "",
+						"enhanced": "",
+						"superior": "",
+						"mastercrafted": ""
+					},
+					"wolven": {
 						"standard": "",
 						"enhanced": "",
 						"superior": "",
@@ -268,6 +304,12 @@
 						"enhanced": "Enhanced Ursine Silver Sword",
 						"superior": "Superior Ursine Silver Sword",
 						"mastercrafted": "Mastercrafted Ursine Silver Sword"
+					},
+					"wolven": {
+						"standard": "Wolven Silver Sword",
+						"enhanced": "Enhanced Wolven Silver Sword",
+						"superior": "Superior Wolven Silver Sword",
+						"mastercrafted": "Mastercrafted Wolven Silver Sword"
 					}
 				},
 				"steelsword": {
@@ -288,6 +330,12 @@
 						"enhanced": "Enhanced Ursine Steel Sword",
 						"superior": "Superior Ursine Steel Sword",
 						"mastercrafted": "Mastercrafted Ursine Steel Sword"
+					},
+					"wolven": {
+						"standard": "Wolven Steel Sword",
+						"enhanced": "Enhanced Wolven Steel Sword",
+						"superior": "Superior Wolven Steel Sword",
+						"mastercrafted": "Mastercrafted Wolven Steel Sword"
 					}
 				},
 				"crossbow": {
@@ -312,6 +360,12 @@
 						"enhanced": "Enhanced Ursine Armor",
 						"superior": "Superior Ursine Armor",
 						"mastercrafted": "Mastercrafted Ursine Armor"
+					},
+					"wolven": {
+						"standard": "Wolven Armor",
+						"enhanced": "Enhanced Wolven Armor",
+						"superior": "Superior Wolven Armor",
+						"mastercrafted": "Mastercrafted Wolven Armor"
 					}
 				},
 				"boots": {
@@ -332,6 +386,12 @@
 						"enhanced": "Enhanced Ursine Boots",
 						"superior": "Superior Ursine Boots",
 						"mastercrafted": "Mastercrafted Ursine Boots"
+					},
+					"wolven": {
+						"standard": "Wolven Boots",
+						"enhanced": "Enhanced Wolven Boots",
+						"superior": "Superior Wolven Boots",
+						"mastercrafted": "Mastercrafted Wolven Boots"
 					}
 				},
 				"gauntlets": {
@@ -352,6 +412,12 @@
 						"enhanced": "Enhanced Ursine Gauntlets",
 						"superior": "Superior Ursine Gauntlets",
 						"mastercrafted": "Mastercrafted Ursine Gauntlets"
+					},
+					"wolven": {
+						"standard": "Wolven Gauntlets",
+						"enhanced": "Enhanced Wolven Gauntlets",
+						"superior": "Superior Wolven Gauntlets",
+						"mastercrafted": "Mastercrafted Wolven Gauntlets"
 					}
 				},
 				"trousers": {
@@ -372,6 +438,12 @@
 						"enhanced": "Enhanced Ursine Trousers",
 						"superior": "Superior Ursine Trousers",
 						"mastercrafted": "Mastercrafted Ursine Trousers"
+					},
+					"wolven": {
+						"standard": "Wolven Trousers",
+						"enhanced": "Enhanced Wolven Trousers",
+						"superior": "Superior Wolven Trousers",
+						"mastercrafted": "Mastercrafted Wolven Trousers"
 					}
 				}
 			}

--- a/files/locales/en/s.json
+++ b/files/locales/en/s.json
@@ -101,7 +101,13 @@
 			"jarlMadmanLugos": "Jarl Madman Lugos",
 			"mastercraftedFelineArmor": "Mastercrafted Feline Armor",
 			"mastercraftedFelineSteelSword": "Mastercrafted Feline Steel Sword",
-			"mastercraftedFelineSilverSword": "Mastercrafted Feline Silver Sword"
+			"mastercraftedFelineSilverSword": "Mastercrafted Feline Silver Sword",
+			"mastercraftedWolvenGauntlets": "Mastercrafted Wolven Gauntlets",
+			"mastercraftedWolvenTrousers": "Mastercrafted Wolven Trousers",
+			"mastercraftedWolvenBoots": "Mastercrafted Wolven Boots",
+			"superiorWolvenSteelSword": "Superior Wolven Steel Sword",
+			"superiorWolvenSilverSword": "Superior Wolven Silver Sword",
+			"superiorWolvenArmor": "Superior Wolven Armor"
 		},
 		"popupTitle": {
 			"ursineSteelSword": "Ursine Steel Sword Diagram",
@@ -119,7 +125,13 @@
 			"jarlMadmanLugos": "Jarl Madman Lugos",
 			"mastercraftedFelineArmor": "Mastercrafted Feline Armor Diagram",
 			"mastercraftedFelineSteelSword": "Mastercrafted Feline Steel Sword Diagram",
-			"mastercraftedFelineSilverSword": "Mastercrafted Feline Silver Sword Diagram"
+			"mastercraftedFelineSilverSword": "Mastercrafted Feline Silver Sword Diagram",
+			"mastercraftedWolvenGauntlets": "Mastercrafted Wolven Gauntlets Diagram",
+			"mastercraftedWolvenTrousers": "Mastercrafted Wolven Trousers Diagram",
+			"mastercraftedWolvenBoots": "Mastercrafted Wolven Boots Diagram",
+			"superiorWolvenSteelSword": "Superior Wolven Steel Sword Diagram",
+			"superiorWolvenSilverSword": "Superior Wolven Silver Sword Diagram",
+			"superiorWolvenArmor": "Superior Wolven Armor Diagram"
 		},
 		"desc": {
 			"juttaAnDimun": "todo",
@@ -138,7 +150,10 @@
 			"jarlMadmanLugos": "You get the Card 'Vampire: Katakan' from him (Gwent Quest: Skellige) (all cards <a href=\"https://wiiare.in/portfolio-type/the-witcher-3-wild-hunt-card-collector-achievement-trophy-guide/\" target=\"_blank\">here</a>",
 			"mastercraftedFelineArmor": "Enter the monster den to the south at the shoreline.  After a little splashing, go to the left when you enter.  All of the armor diagrams will be in the chest there (Mastercrafted Feline Armor, Gautlets, Trousers and Boots).",
 			"mastercraftedFelineSteelSword": "When entering the monster den and fighting off foes, go left, as your climbing up the stairs there is a small alcove on the left. The diagram is in the chest.",
-			"mastercraftedFelineSilverSword": "Enter the monster den, go to the right and the wall crumbles.  The diagram is in a chest right there."
+			"mastercraftedFelineSilverSword": "Enter the monster den, go to the right and the wall crumbles.  The diagram is in a chest right there.",
+			"mastercraftedWolvenTrousers": "You must climb the wall of the old watchtower.",
+			"superiorWolvenSteelSword": "Going down to the catacomb and enter a room filled with poison gas",
+			"superiorWolvenArmor": "You need to get to the second floor of the fortress"
 		}
 	},
 	"pop": {


### PR DESCRIPTION
Features:
* Fix Yoana (node "popup").
* Add Witcher Gear - Wolven school Gear => Velen/Novigrad and Isles Skellige.
* Add locales Witcher Gear - Wolven school Gear => "locales/en/general.json" and "locales/en/s.json"

Unfortunately for 2 maps no unification (this question remains open):
* The scripts for the Skellige for "POI" number of nodes is less than Velen/Novigrad.
Example => "poi.desc.witcherGear.silversword.wolven.enhanced" (Velen/Novigrad), "s:poi.desc.mastercraftedWolvenGauntlets" (Skellige).
6 nodes vs 4 nodes.
* For Skellige description taken from the file "locales/en/s.json", but in Velen/Novigrad description taken from the general file - "locales/en/general.json".
While far from the unification, but it is impossible to carry out, unnecessarily. In this case it violated the structure of the files that are in the translation: https://crowdin.com/project/witcher3map