### PR TITLE
Adding monster details to 1 guarded treasure.

### DIFF
--- a/files/js/mapdata-velen.js
+++ b/files/js/mapdata-velen.js
@@ -414,7 +414,7 @@ $(document).on("loadMapdata", function () {
 		}, { // NW Velen
 			coords: [[4.193, -82.463]],
 			label: $.t("guarded.label"),
-			popup: 'Available after the \'Master Armorers\' (lvl 26) quest. ' + $.t("guarded.desc", {monster: ""})
+			popup: 'Available after the \'Master Armorers\' (lvl 26) quest. ' + $.t("guarded.desc", {monster: "(lvl 19 <span>" + $.t("v:monsters.cyclops") + "</span>)"})
 		}, {
 			coords: [[-62.39, -118.17]],
 			label: $.t("guarded.label"),


### PR DESCRIPTION
Added monster details (lvl 19 Cyclops) to guarded treasure at 4.193, -82.463.